### PR TITLE
Update ru.json

### DIFF
--- a/ru.json
+++ b/ru.json
@@ -486,15 +486,15 @@
 		}
 	},
 	"nouns": {
-		"word-with-count": "{{count}} word",
-		"word-with-count_plural": "{{count}} words",
-		"character-with-count": "{{count}} character",
-		"character-with-count_plural": "{{count}} characters",
-		"link-with-count": "{{count}} link",
-		"link-with-count_plural": "{{count}} links",
-		"file-with-count": "{{count}} file",
-		"file-with-count_plural": "{{count}} file",
-		"backlink-with-count": "{{count}} backlink",
-		"backlink-with-count_plural": "{{count}} backlinks"
+		"word-with-count": "{{count}} слово",
+		"word-with-count_plural": "{{count}} слов",
+		"character-with-count": "{{count}} символ",
+		"character-with-count_plural": "{{count}} символов",
+		"link-with-count": "{{count}} ссылка",
+		"link-with-count_plural": "{{count}} ссылок",
+		"file-with-count": "{{count}} файл",
+		"file-with-count_plural": "{{count}} файлов",
+		"backlink-with-count": "{{count}} обратная ссылка",
+		"backlink-with-count_plural": "{{count}} обратных ссылок"
 	}
 }


### PR DESCRIPTION
Added translations just for nouns, should not conflict with #18 

for `_plural` I used versions typical for counts ending with [5, 6, 7, 8, 9, 0, 11...19], since they are more common.

Generally, the rule in Russian is:
- 1 ссылка, 21 ссылка, 101 ссылка
- [2, 3, 4] ссылки, 22 ссылки, 102 ссылки
- [5, 6, 7, 8, 9, 0] ссылок, 25 ссылок, 105 ссылок, 100 ссылок
- [11...19] ссылок, 111 ссылок, 1011 ссылок