### PR TITLE
Add Ellipsis to publish action

### DIFF
--- a/en.json
+++ b/en.json
@@ -800,7 +800,7 @@
 		"publish": {
 			"name": "Publish",
 			"desc": "Publish your notes through Obsidian Publish.",
-			"action-publish-changes": "Publish changes",
+			"action-publish-changes": "Publish changes...",
 			"label-no-internet-access": "You need access to the internet to publish changes.",
 			"label-publish-service-description": "Obsidian Publish is an add-on paid service that lets you publish your notes online directly from Obsidian.",
 			"label-please-login": "To start publishing, please log in or create a new Obsidian account.",


### PR DESCRIPTION
The publish action opens an intermediate modal. The `...` will signal to users that the action isn't immediate and might make it more welcoming.