### PR TITLE
ru: label-unlinked-mentions fix

### DIFF
--- a/ru.json
+++ b/ru.json
@@ -712,7 +712,7 @@
 			"tab-title": "Исходящие ссылки из {{displayText}}",
 			"label-links": "Ссылки",
 			"label-no-links": "Ссылок не найдено.",
-			"label-unlinked-mentions": "Не связанные упоминания",
+			"label-unlinked-mentions": "Упоминания без ссылки",
 			"tooltip-link-file": "Связать с этим файлом",
 			"tooltip-not-created": "Еще не создан"
 		},


### PR DESCRIPTION
ru: label-unlinked-mentions fixed by reason: unity of terminology for backlinks and outgoing links.