### PR TITLE
ja: keep "Finder" as-is

### DIFF
--- a/ja.json
+++ b/ja.json
@@ -576,7 +576,7 @@
 			"option-new-vault-location-description": "新規保管庫の作成場所を指定してください。",
 			"label-new-vault-location-preview": "新規保管庫は以下の場所に配置されます: ",
 			"option-reveal-vault-in-explorer": "システムのエクスプローラで表示",
-			"option-reveal-vault-in-explorer-mac": "保管庫をファインダーで表示",
+			"option-reveal-vault-in-explorer-mac": "保管庫をFinderに表示",
 			"option-rename-vault": "保管庫の名前を変更…",
 			"msg-error-rename-exists": "同じ名前の保管庫がすでに存在しています。",
 			"msg-error-nested": "自身のサブフォルダに移動することはできません。",
@@ -1210,7 +1210,7 @@
 			"action-open-file": "デフォルトアプリで開く",
 			"action-open-file-mobile": "共有",
 			"action-show-in-folder": "フォルダで表示",
-			"action-show-in-folder-mac": "ファインダーで表示"
+			"action-show-in-folder-mac": "Finderに表示"
 		},
 		"templates": {
 			"name": "テンプレート",


### PR DESCRIPTION
Name of Finder.app is shouldn't localized on Japanese (and probably all languages?).

also Apple uses "Finder**に**表示" instead of "Finder**で**表示" (see https://applelocalization.com/?q=in+Finder&l=English&l=Japanese ) , so I follow it.