### PR TITLE
feat: setup Crowdin

### DIFF
--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -1,0 +1,41 @@
+# This workflow will run Crowdin Action that will upload new texts to Crowdin, download the newest translations and create a PR
+# For more information see: https://github.com/crowdin/github-action
+
+name: Crowdin Sync
+
+on:
+  schedule:
+    - cron: '0 */6 * * *' # Every 6 hours - https://crontab.guru/#0_*/6_*_*_*
+  push:
+    branches: [ master, feat/setup-crowdin ]
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Crowdin
+        uses: crowdin/github-action@v1
+        with:
+          # Upload sources to Crowdin
+          upload_sources: true
+          # Upload translations to Crowdin, only use true at initial run
+          upload_translations: false
+          # Download translations from Crowdin
+          download_translations: true
+          # To the specified branch
+          localization_branch_name: l10n_crowdin_translations
+          # Create pull request after pushing to branch
+          create_pull_request: true
+          pull_request_title: 'New Crowdin Translations'
+          pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
+          pull_request_base_branch_name: 'master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,68 @@
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+"base_path": "."
+
+"preserve_hierarchy": true
+
+"files": [
+  {
+    "source": "en.json",
+    "translation": "%locale%.json",
+    "languages_mapping": {
+      "locale": {
+        "af": "af",
+        "am": "am",
+        "ar": "ar",
+        "be": "be",
+        "bg": "bg",
+        "bn": "bn",
+        "ca": "ca",
+        "cs": "cs",
+        "da": "da",
+        "de": "de",
+        "el": "el",
+        "eo": "eo",
+        "es-ES": "es",
+        "eu": "eu",
+        "fa": "fa",
+        "fi": "fi",
+        "fr": "fr",
+        "gl": "gl",
+        "he": "he",
+        "hi": "hi",
+        "hu": "hu",
+        "id": "id",
+        "it": "it",
+        "ja": "ja",
+        "ko": "ko",
+        "lt": "lt",
+        "lv": "lv",
+        "ml-IN": "ml",
+        "ms": "ms",
+        "nl": "nl",
+        "nn-NO": "nn",
+        "no": "no",
+        "oc": "oc",
+        "pl": "pl",
+        "pt-PT": "pt",
+        "pt-BR": "pt-BR",
+        "ro": "ro",
+        "ru": "ru",
+        "se": "se",
+        "sk": "sk",
+        "sq": "sq",
+        "sr": "sr",
+        "ta": "ta",
+        "te": "te",
+        "th": "th",
+        "tr": "tr",
+        "uk": "uk",
+        "ur-IN": "ur",
+        "uz": "uz",
+        "vi": "vi",
+        "zh-CN": "zh",
+        "zh-TW": "zh-TW",
+      }
+    }
+  }
+]


### PR DESCRIPTION
Hey everyone 👋 

It's Andrii from Crowdin. Just did some analysis of the current i18n workflow and it feels like GitHub issues and PRs reported by the community are not so easy to handle. The community translators can work together in Crowdin, translations would be delivered as PR and volunteers can raise issues for problematic strings via Crowdin.

I'm suggesting the integration with Crowdin via GitHub Actions. Crowdin is free for open-source projects. This integration works in the following way:
- the action runs every 6 hours (it's up to you what trigger to use, it could also be a push to the default branch, for example)
- upload new source texts to the Crowdin project
- upload existing translations to Crowdin (using the `upload_translations` action config parameter, it's necessary only for the first time)
- download all the new translations from Crowdin and commit these translations to the `localization_branch_name`
- open a Pull Request with the latest translations.

You can find my demo Crowdin project here - [obsidianmd-demo](https://crowdin.com/project/obsidianmd-demo).

Example of the first PR that will be created by Crowdin Action - [#1](https://github.com/andrii-bodnar/obsidian-translations/pull/1/commits/d56f8aefc94f8d3ab53ce60bae8e92ba9b735954) (Don't worry about the diffs - it's just updated the translation files to the actual state. The next PRs will include the new translations only).