### PR TITLE
Corrects French translation error and syntax errors specific to French

### DIFF
--- a/fr.json
+++ b/fr.json
@@ -74,7 +74,7 @@
 			"msg-vim-mode-not-enabled": "La commande étant incorrecte, le mode Vim reste désactivé pour vous protéger.",
 			"msg-vim-mode-please-enter-command": "Entrer la commande pour activer le mode Vim",
 			"option-legacy-editor": "Utiliser l'ancien éditeur",
-			"option-legacy-editor-description2": "L'ancien éditeur sera prochainement déprécié. Il n'est actuellement plus maintenant, et par conséquent, les bugs ne seront plus corrigés .",
+			"option-legacy-editor-description2": "L'ancien éditeur sera prochainement déprécié. Il n'est actuellement plus maintenu, et par conséquent, les bugs ne seront plus corrigés.",
 			"label-legacy-deprecation": "Le nouvel éditeur est ici.",
 			"label-legacy-deprecation-1": "Obsidian dispose désormais d'un tout nouvel éditeur, plus robuste et plus accessible.",
 			"label-legacy-deprecation-2": "Il semble que vous utilisez toujours l'ancien éditeur, et nous pensons que vous apprécierez le nouveau éditeur.",
@@ -121,7 +121,7 @@
 			"option-excluded-files": "Fichiers exclus",
 			"option-excluded-files-desc": "Les fichiers exclus seront soit masqués, soit moins visibles à divers endroits, notamment dans le sélecteur rapide, la suggestion de liens et la vue graphique.",
 			"label-no-excluded-filters-applied": "Aucun filtre d'exclusion n'est appliqué pour le moment. Ajoutez-en un en dessous.",
-			"label-excluded-filters-applied": "Les fichiers correspondant aux filtres suivants sont actuellement exclus :",
+			"label-excluded-filters-applied": "Les fichiers correspondant aux filtres suivants sont actuellement exclus : ",
 			"label-excluded-filter": "Filtre",
 			"message-empty-filter": "Le filtre ne peut être vide",
 			"placeholder-excluded-filter": "Entrer un chemin ou un \"/regex/\"..."


### PR DESCRIPTION
Hi,

While browsing the software settings, I noticed that there was an error in the French translation. I corrected it and took the opportunity to correct the syntax specific to the French language concerning the spaces before and after certain characters.

