### PR TITLE
Update zh.json

### DIFF
--- a/zh.json
+++ b/zh.json
@@ -739,7 +739,7 @@
 		"toggle-right-sidebar": "折叠/展开右侧边栏",
 		"toggle-default-new-tab-mode": "切换新标签页的默认视图",
 		"focus-editor": "将焦点切换至编辑区",
-		"toggle-fold-properties": "Toggle fold properties in current file",
+		"toggle-fold-properties": "折叠/展开当前文档属性",
 		"toggle-fold": "折叠/展开当前行",
 		"fold-all": "折叠所有标题和列表",
 		"unfold-all": "展开所有标题和列表",


### PR DESCRIPTION
Translates a missing command.

Seems like the simplified Chinese is maintained by this official repo? Then update the `readme` would provide a clearer instruction.