### PR TITLE
minor editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Here is a table of language code to language name, in alphabetical order. These 
 | `it` | Italian | Italiano | ✅ |
 | `ja` | Japanese | 日本語 | ✅ |
 | `ko` | Korean | 한국어 | ✅ |
-| `lv` | Latvian | Latviešu valoda | ✅ |
+| `lv` | Latvian | Latviešu | ✅ |
 | `ml` | Malayalam | മലയാളം | 🚧 |
 | `ms` | Malay | Bahasa Melayu | 🚧 |
 | `ne` | Nepali | नेपाली | ✅ |


### PR DESCRIPTION
«Latviešu Valoda» translates to «Latvian Language», which is redundant since we are already selecting the language in the «Language» section. Therefore, just «Latviešu» is sufficient. This will maintain conciseness, logic, and consistency.