### PR TITLE
pt-BR: fix action-column-after typo

### DIFF
--- a/pt-BR.json
+++ b/pt-BR.json
@@ -2418,7 +2418,7 @@
 		"label-column": "Coluna",
 		"label-row": "Linha",
 		"action-row-after": "Inserir linha abaixo",
-		"action-column-after": "Inserir coluna abaixo",
+		"action-column-after": "Inserir coluna à direita",
 		"action-row-before": "Inserir linha acima",
 		"action-row-up": "Mover linha para cima",
 		"action-row-down": "Mover linha para baixo",


### PR DESCRIPTION
The correct text to "action-column-after" should be "Inserir coluna à direita" and not "Inserir coluna abaixo": column is in horizontal line, "abaixo" is a vertical direction (see "action-row-after" text for comparison).