### PR TITLE
fix: wrong toggle for landscape

### DIFF
--- a/pt-BR.json
+++ b/pt-BR.json
@@ -491,7 +491,7 @@
 			"setting-page-size-letter": "Carta",
 			"setting-page-size-tabloid": "Tabloide",
 			"setting-include-file-name": "Incluir nome do arquivo como título",
-			"setting-landscape": "Retrato",
+			"setting-landscape": "Paisagem",
 			"setting-margin": "Margem",
 			"setting-margin-default": "Padrão",
 			"setting-margin-minimal": "Mínima",


### PR DESCRIPTION
The toggle label was incorrectly set to "Retrato" (Portrait) while it actually enabled landscape mode. The label has been updated to "Paisagem" to correctly reflect its function.

![image](https://github.com/user-attachments/assets/e0c3aeed-a722-4bf3-a70a-3b90e1c3eebf)
