### PR TITLE
Update Finnish strings for v1.9.7; also change quotation marks used

### DIFF
--- a/fi.json
+++ b/fi.json
@@ -1737,7 +1737,7 @@
 			"label-configure-custom-domain": "Määritä mukautettu verkkotunnus",
 			"option-custom-url-name": "Mukautettu verkko-osoite",
 			"option-custom-url-desc": "Syötä sivustosi verkko-osoite ilman ”www.”-alkuosaa.",
-			"option-custom-url-placeholder": "sivustosi.fi",
+			"option-custom-url-placeholder": "example.com",
 			"option-custom-url-redirect": "Ohjaa mukautettuun verkkotunnukseesi",
 			"option-custom-url-redirect-desc": "Ohjaa publish.obsidian.md/id-osoitteen kävijät automaattisesti mukautettuun verkkotunnukseesi.",
 			"button-update-custom-domain": "Muuta verkkotunnusasetuksia",


### PR DESCRIPTION
U+201D is the standard Finnish quotation mark, so I've replaced all instances of quotation marks in strings within `fi.json` with that.