### PR TITLE
NL: correct "remove file"

### DIFF
--- a/nl.json
+++ b/nl.json
@@ -630,7 +630,7 @@
 			"toggle-source-mode": "Bronweergave",
 			"toggle-reading-view": "Leesweergave",
 			"add-property": "Voeg bestandseigenschap toe",
-			"delete-file": "Wissen bestand",
+			"delete-file": "Verwijder bestand",
 			"create-file": "Maak dit bestand aan",
 			"open-link": "Link openen",
 			"open-in-new-tab": "Open in nieuw tabblad",


### PR DESCRIPTION
"Wissen bestand" is grammatically incorrect, made consistent with the other menu options