### PR TITLE
Translate "insert-footnote" to Japanese

### DIFF
--- a/ja.json
+++ b/ja.json
@@ -1042,7 +1042,7 @@
 		"insert-codeblock": "コードブロック",
 		"insert-math-block": "数学ブロック",
 		"insert-table": "テーブル",
-		"insert-footnote": "Footnote",
+		"insert-footnote": "脚注",
 		"toggle-bullet-list": "バレットリスト",
 		"toggle-numbered-list": "順序付きリスト",
 		"toggle-checklist": "タスクリスト",


### PR DESCRIPTION
This PR translates the menu-item `insert-footnote` from English ("Footnote") to Japanese ("脚注").

## Notes for Reviewers

- Only the `menu-items` section in `ja.json` was modified.
- No other keys or functionality were changed.
- This PR is part of ongoing efforts to complete the Japanese translation of Obsidian UI.

Thank you for reviewing! 