### PR TITLE
More corections to the Danish language file

### DIFF
--- a/translations/da.txt
+++ b/translations/da.txt
@@ -84,7 +84,7 @@ translation=Begræns maksimal linjelængde. Rummer mindre indhold på skærmen, 
 
 [setting.editor.option-strict-line-break]
 original=Strict line breaks
-translation=Strenge linjeskift
+translation=Strikse linjeskift
 
 [setting.editor.option-strict-line-break-description]
 original=Markdown specs ignore single line breaks in reading view. Turn this off to make single line breaks visible.
@@ -164,7 +164,7 @@ translation=Redigeringsvisning
 
 [setting.editor.option-default-new-tab-view-reading]
 original=Reading view
-translation=Læsevisning
+translation=Læsningsvisning
 
 [setting.editor.option-open-tab-in-foreground]
 original=Always focus new tabs
@@ -384,11 +384,11 @@ translation=Hvor nye noter skal placeres. Plugin-indstillinger tilsidesætter de
 
 [setting.file.option-choice-vault-root]
 original=Vault folder
-translation=Boks-mappe
+translation=Boksmappe
 
 [setting.file.option-choice-current-folder]
 original=Same folder as current file
-translation=Samme mappe, hvor filen ligger
+translation=I Samme mappe som nuværende fil
 
 [setting.file.option-choice-specified-folder]
 original=In the folder specified below
@@ -2204,7 +2204,7 @@ translation=Tilføj eksternt link
 
 [interface.formatting.insert-callout]
 original=Callout
-translation=Bemærkning
+translation=Boble
 
 [interface.formatting.insert-horizontal-rule]
 original=Horizontal rule
@@ -3636,7 +3636,7 @@ translation=Skift mellem punkter/afkrydsningsfelter
 
 [commands.insert-callout]
 original=Insert callout
-translation=Indsæt bemærkning
+translation=Indsæt boble
 
 [commands.insert-code-block]
 original=Insert code block
@@ -4024,7 +4024,7 @@ translation=Erstat
 
 [menu-items.insert-callout]
 original=Callout
-translation=Bemærkning
+translation=Boble
 
 [menu-items.insert-markdown-link]
 original=Markdown Link
@@ -9756,7 +9756,7 @@ translation=Tabel: {{command}}
 
 [callout.option-type]
 original=Callout type
-translation=Bemærkningstype
+translation=Bobletype
 
 [callout.type.info]
 original=Info
@@ -9800,7 +9800,7 @@ translation=Andre...
 
 [callout.option-other-placeholder]
 original=Callout type...
-translation=Bemærkningstype...
+translation=Bobletype...
 
 [nouns.count]
 original={{count}}


### PR DESCRIPTION
Some small language corrections found when translating the Obsidian Help to Danish.