### PR TITLE
Fix invalid usage of Functional word

### DIFF
--- a/translations/ru.txt
+++ b/translations/ru.txt
@@ -2212,7 +2212,7 @@ translation=Удалить
 
 [interface.msg-indexing]
 original=Indexing vault...
-translation=Obsidian индексирует хранилище...\nЭто должно произойти лишь единожды.\nНекоторая функциональность может быть недоступна пока процесс не закончен.
+translation=Хранилище индексируется...
 
 [interface.msg-indexing-desc]
 original=Some functionality may not be available until this is complete.


### PR DESCRIPTION
This is a common mistake: instead of the word "functionality", people use the word "functional", which is wrong, because "functional" is a concept from mathematics, and the word "functionality" should be used in relation to software.

Это частая ошибка: вместо слова «функциональность» люди употребляют слово «функционал», что неправильно, т. к. «функционал» — это понятие из математики, а по отношению к программному обеспечению должно употребляться слово «функциональность».