### PR TITLE
i18n: Add Kabyle (kab) translation for Obsidian

### DIFF
--- a/translations/kab.txt
+++ b/translations/kab.txt
@@ -1,0 +1,10067 @@
+[setting.options]
+original=Options
+translation=Iɣewwaṛen
+
+[setting.plugin]
+original=Plugin
+translation=Azegrir
+
+[setting.builtin-plugins]
+original=Core plugins
+translation=Izegrar igejdanen
+
+[setting.plugin-options]
+original=Plugin options
+translation=Iɣewwaṛen n uzegrir
+
+[setting.folder-path-example-placeholder]
+original=Example: folder 1/folder 2
+translation=Amedya: akaram 1/akaram 2
+
+[setting.file-path-example-placeholder]
+original=Example: folder/note
+translation=Amedya: akaram/tazmilt
+
+[setting.msg-restart-required]
+original=Changing this option requires a restart to take effect.
+translation=Abeddel n tnefrunt-agi yesra tulsa n usekker iwakken ad yeddu.
+
+[setting.editor.name]
+original=Editor
+translation=Amaẓrag
+
+[setting.editor.section-behavior]
+original=Behavior
+translation=Tiddin
+
+[setting.editor.section-display]
+original=Display
+translation=Abeqqeḍ
+
+[setting.editor.option-spellcheck]
+original=Spellcheck
+translation=Asenqed n teɣdirawt
+
+[setting.editor.option-spellcheck-description]
+original=Turn on the spellchecker.
+translation=Rmed asenqed n teɣdirawt.
+
+[setting.editor.spellcheck-languages]
+original=Spellcheck languages
+translation=Tutlayin n usenqed n teɣdirawt
+
+[setting.editor.spellcheck-languages-description]
+original=Choose the languages for the spellchecker to use.
+translation=Fren tutlayin i usenqed n teɣdirawt ara yettusqedcen.
+
+[setting.editor.spellcheck-languages-mac-description]
+original=The native spellchecker will automatically detect the language being used for you on macOS.
+translation=Amseɣtay n teɣdirawt adigan ad d-yaf s wudem awurman tutlayt i yettwasqedcen deg macOS.
+
+[setting.editor.spellcheck-dict]
+original=Spellcheck dictionary
+translation=Amawal n eqenqed n teɣdirawt
+
+[setting.editor.spellcheck-dict-empty]
+original=The spellcheck dictionary is empty.
+translation=Amawal n eqenqed n teɣdirawt d ilem.
+
+[setting.editor.option-show-inline-title]
+original=Inline title
+translation=Azwel deg izirig
+
+[setting.editor.option-show-inline-title-description]
+original=Display the filename as an editable title inline with the file contents.
+translation=Beqqeḍ isem n ufaylu d azwel yettwaẓragen deg izirig akked ugbur n ufaylu.
+
+[setting.editor.option-readable-line-length]
+original=Readable line length
+translation=Teɣzi n yizirig yettwaɣran
+
+[setting.editor.option-readable-line-description]
+original=Limit maximum line length. Less content fits onscreen, but long blocks of text are more readable.
+translation=Eg talast i teɣzi tafellayt n izirig. Drus n ugbur i d-yeffɣen ɣef ugdil, maca iḥedren n uḍris ad ttwaɣren xir.
+
+[setting.editor.option-strict-line-break]
+original=Strict line breaks
+translation=Tuɣalin ɣer yizirig qesḥanen
+
+[setting.editor.option-strict-line-break-description]
+original=Markdown specs ignore single line breaks in reading view. Turn this off to make single line breaks visible.
+translation=Isemliyen n Markdown ttezgilent tuɣalin tiḥerfiyin ɣer yizirig deg tmuɣli n tɣuri. Ssens ayagi i wakken ad d-banent tuɣalin tiḥerfiyin ɣer yizirig.
+
+[setting.editor.option-properties-in-document]
+original=Properties in document
+translation=Iraten deg isemli
+
+[setting.editor.option-properties-in-document-description]
+original=Choose how properties are displayed at the top of notes. Select “source” to show properties as raw YAML.
+translation=Fren amek ara ttwabeqḍen iraten deg uksawen n tezmilin. Fren "aɣbalu" i waskan n iraten am YAML.
+
+[setting.editor.option-properties-hidden]
+original=Hidden
+translation=Uffir
+
+[setting.editor.option-properties-visible]
+original=Visible
+translation=Yettbanay
+
+[setting.editor.option-properties-source]
+original=Source
+translation=Aɣbalu
+
+[setting.editor.option-auto-pair-brackets]
+original=Auto-pair brackets
+translation=Tiddukla tawurmant n yisenfaf
+
+[setting.editor.option-auto-pair-brackets-description]
+original=Pair brackets and quotes automatically.
+translation=Seddukel isenfaf d tacciwin s wudem awurman.
+
+[setting.editor.option-auto-pair-markdown]
+original=Auto-pair Markdown syntax
+translation=Tiddukla tawurmant n tseddast Markdown
+
+[setting.editor.option-auto-pair-markdown-description]
+original=Pair symbols automatically for bold, italic, code, and more.
+translation=Seddukel izmulen s wudem awurman i uzuran, uknan, tangalt, d wayen nniḍen.
+
+[setting.editor.option-smart-indent-lists]
+original=Smart lists
+translation=Tibdarin timegza
+
+[setting.editor.option-smart-indent-lists-description]
+original=Automatically set indentation and place list items correctly.
+translation=Sbadu s wudem awurman asiẓi arnu sers iferdisen n tebdart akken iwata.
+
+[setting.editor.option-fold-heading]
+original=Fold heading
+translation=Ḍfes tasenṭit
+
+[setting.editor.option-fold-heading-description]
+original=Lets you fold all content under a heading.
+translation=Ḍfes akk agbur ddaw n tsenṭit.
+
+[setting.editor.option-fold-indent]
+original=Fold indent
+translation=Ḍfes asiẓi
+
+[setting.editor.option-fold-indent-description]
+original=Lets you fold part of an indentation, such as lists.
+translation=Ḍfes aḥric seg usiẓi, am tebdarin.
+
+[setting.editor.option-default-new-tab-view]
+original=Default view for new tabs
+translation=Taskant tamezwert i yiccaren imaynuten
+
+[setting.editor.option-default-new-tab-view-description]
+original=The default view that a new Markdown tab gets opened in.
+translation=Taskant tamezwert anda iccer Markdown amaynut ad yeldi deg-s.
+
+[setting.editor.option-default-new-tab-view-editing]
+original=Editing view
+translation=Taskant usiẓreg
+
+[setting.editor.option-default-new-tab-view-reading]
+original=Reading view
+translation=Taskant n tɣuṛi
+
+[setting.editor.option-open-tab-in-foreground]
+original=Always focus new tabs
+translation=Yal tikkelt asaḍas ɣef yiccaren imaynutin
+
+[setting.editor.option-open-tab-in-foreground-description]
+original=When you open a link in a new tab, switch to it immediately.
+translation=Ma teldiḍ-d aseɣwen deg yiccer amaynut, ddu din din ɣur-s.
+
+[setting.editor.option-default-editing-mode]
+original=Default editing mode
+translation=Askar n usiẓreg amezwer
+
+[setting.editor.option-default-editing-mode-description]
+original=The default editing mode a new tab will start with.
+translation=Askar n teẓrigt amezwer ad yebdu s yiccer amaynut.
+
+[setting.editor.option-default-editing-mode-source]
+original=Source mode
+translation=Askar n uɣbalu
+
+[setting.editor.option-default-editing-mode-live-preview]
+original=Live Preview
+translation=Taskant s wudem usrid
+
+[setting.editor.option-show-line-number]
+original=Line numbers
+translation=Uṭṭunen n izirigen
+
+[setting.editor.option-show-line-number-description]
+original=Show line numbers in the gutter.
+translation=Sken uṭṭunen n izirigen deg yidis.
+
+[setting.editor.option-indentation-guide]
+original=Indentation guides
+translation=Iminigen n usiẓi
+
+[setting.editor.option-indentation-guide-description]
+original=Show vertical relationship lines between list items.
+translation=Sken izirigen ibeddayen n wassaɣ gar yiferdisen n tebdart.
+
+[setting.editor.option-use-tabs]
+original=Indent using tabs
+translation=Siẓi s useqdec n yiccaren
+
+[setting.editor.option-use-tabs-description]
+original=Use tabs to indent by pressing the “Tab” key. Turn this off to indent using 4 spaces.
+translation=Seqdec iccaren i usiẓi s tuqqna ɣef tqeffalt “Tab”. Ssens ayagi i wakken ad tsiẓiḍ s 4 n tallunin.
+
+[setting.editor.option-tab-size]
+original=Indent visual width
+translation=Tehri tawezlant n usiẓi
+
+[setting.editor.option-tab-size-description]
+original=Number of spaces a tab character will render as.
+translation=Amḍan n tallunin i d-yettbanen am usekkil n yiccer.
+
+[setting.editor.option-rtl]
+original=Right-to-left (RTL)
+translation=Seg uyeffus ɣer uzelmaḍ  (RTL)
+
+[setting.editor.option-rtl-description]
+original=Sets the default text direction of notes to right-to-left.
+translation=Sbadu tanila n uḍris amezwer n tezmilin seg uyeffus ɣer uzelmaḍ.
+
+[setting.editor.option-auto-convert-html]
+original=Convert pasted HTML to Markdown
+translation=Selket HTML yettwasenṭeḍ ɣer Markdown
+
+[setting.editor.option-auto-convert-html-description]
+original=Automatically convert HTML to Markdown when pasting and drag-and-drop from web pages. Use Ctrl/Cmd+Shift+V to paste HTML without converting.
+translation=Selket HTML s wudem awurman ɣer Markdown mi ara tsenṭeḍ neɣ mi ara tzuɣreḍ seg isebtar n web. Seqdec Ctrl/Cmd+Shift+V i wusneṭeḍ n HTML war aselket.
+
+[setting.editor.option-vim-key-bindings]
+original=Vim key bindings
+translation=tuqniwin n tsura Vim
+
+[setting.editor.option-vim-key-bindings-description]
+original=Use Vim key bindings when editing.
+translation=Seqdec tuqniwin n tsura Vim ticki telliḍ seg usiẓreg.
+
+[setting.editor.option-vim-key-bindings-mobile]
+original=On mobile devices, this setting is per-device and is not synchronized through the config file.
+translation=Deg yiberyan izirazen, aɣewwaṛ-a ibedd ɣef yal ibenk yerna ur yettwamtawa ara s ufaylu n twila.
+
+[setting.editor.option-reindex-vault]
+original=Rebuild vault cache
+translation=Ales asali n tzarkatut n wakaram n weḥrez
+
+[setting.editor.option-reindex-vault-description]
+original=Rebuilding the cache could take a few seconds to a few minutes depending on the size of your vault.
+translation=Allus n usali n tzarkatut yezmer ad yeṭṭef kra n tsinin ar kra n tesdatin ɣef leḥsab n tiddi n wammud-ik·im.
+
+[setting.editor.label-reindex]
+original=Rebuild
+translation=Ales lebni
+
+[setting.editor.label-confirm-enable-vim]
+original=Confirm entering Vim mode
+translation=Sentem anekcum ɣer uskar Vim
+
+[setting.editor.label-vim-warning]
+original=Vim mode is for efficient text editing but can be quite counter-intuitive. If you're not familiar with Vim, this option might make it look like Obsidian has stopped working.
+translation=Askar Vim d win n teẓrigt tamellayt n uḍris maca yezmer ad yili ur yettwassen ara aṭas. Ma yella ur tessineḍ ara Vim, taxtiṛit-a tezmer ad teg amzun Obsidian am akken yeḥbes.
+
+[setting.editor.label-vim-test]
+original=To verify that you know your way around Vim, please enter the command to quit Vim without saving below:
+translation=I wakken ad nessiweḍ ad nẓer belli tessineḍ Vim, ttxil-k·im sekcem taladna i tuffɣa seg Vim war asekles ddaw-a:
+
+[setting.editor.label-vim-your-answer]
+original=Your answer
+translation=Tiririt-ik·im
+
+[setting.editor.placeholder-enter-command]
+original=Enter command...
+translation=Sekcem taladna...
+
+[setting.editor.button-confirm-enable-vim]
+original=Let me enable Vim
+translation=Eǧǧ-iyi ad remdeɣ Vim
+
+[setting.editor.msg-vim-mode-enabled]
+original=Command is correct. Vim mode now enabled.
+translation=Taladna d tameɣtut. Askar Vim yermed tura.
+
+[setting.editor.msg-vim-mode-not-enabled]
+original=Command is incorrect. Vim mode remains disabled to protect you.
+translation=Taladna mačči d tameɣtut. Askar n Vim ad d-yiqem yensa akken ad yemmesten fell-ak·am.
+
+[setting.editor.msg-vim-mode-please-enter-command]
+original=Please enter the command to enable Vim mode
+translation=Ttxil-k·m sekcem taladna iwakken ad tesremdeḍ askar Vim
+
+[setting.file.name]
+original=Files and links
+translation=Ifuyla akked iseɣwanen
+
+[setting.file.option-confirm-file-deletion]
+original=Confirm before deleting files
+translation=Sentem send tukksa n yifuyla
+
+[setting.file.option-confirm-file-deletion-description]
+original=Avoid accidentally deleting files.
+translation=Ur ttaǧǧa ara ad tekkseḍ ifuyla s leɣlaḍ.
+
+[setting.file.option-trash]
+original=Trash
+translation=Iḍummen
+
+[setting.file.option-delete-destination]
+original=Deleted files
+translation=Ifuyla yettwakksen
+
+[setting.file.option-delete-destination-description]
+original=What happens to a file after you delete it.
+translation=D acu ara yeḍrun i ufaylu deffir n tukksa-ines.
+
+[setting.file.option-choice-system-trash]
+original=Move to system trash
+translation=Smutti ɣer yiḍummen n unagraw
+
+[setting.file.option-choice-vault-trash]
+original=Move to Obsidian trash (.trash folder)
+translation=Smutti ɣer yiḍummen n Obsidian (akaram .trash)
+
+[setting.file.option-choice-permanent-delete]
+original=Permanently delete
+translation=Kkes s wudem imezgi
+
+[setting.file.option-delete-unlinked-attachments]
+original=Delete attachments when deleting files
+translation=Kkes imeddayen mi ara tekkseḍ ifuyla
+
+[setting.file.option-delete-unlinked-attachments-description]
+original=Automatically remove attachments linked to the deleted file if they're not used elsewhere.
+translation=Kkes s wudem awurman imeddayen yeqqnen ɣer ufaylu yettwakksen ma yella ur ttuseqdacen ara deg wemkan nniḍen.
+
+[setting.file.option-choice-always]
+original=Always
+translation=Yal tikkelt
+
+[setting.file.option-choice-ask-every-time]
+original=Ask each time
+translation=Seqsi yal tikkelt
+
+[setting.file.option-choice-never]
+original=Never
+translation=Werǧin
+
+[setting.file.option-default-open-action]
+original=Default file to open
+translation=Afaylu amezwer i welday
+
+[setting.file.option-default-open-action-description]
+original=Choose which file to open when the app starts.
+translation=Fren d acu n ufaylu ara yeldin mi ara yekker usnas.
+
+[setting.file.option-choice-last-opened]
+original=Last opened
+translation=Aneggaru i yeldin
+
+[setting.file.option-choice-new-note]
+original=New note
+translation=Tazmilt tamaynut
+
+[setting.file.option-choice-specific-file]
+original=Specific file
+translation=Afaylu uzzig
+
+[setting.file.option-choice-daily-note]
+original=Daily note
+translation=Tazmilt n yal ass
+
+[setting.file.option-default-open-file-path]
+original=File to open
+translation=Afaylu ara yeldin
+
+[setting.file.option-default-open-file-path-description]
+original=Select a specific file to open by default.
+translation=Fren afaylu uzzig ara yeldin s wudem amezwer.
+
+[setting.file.option-always-update-links]
+original=Automatically update internal links
+translation=Leqqem s wudem awurman isɣewnen idiganen
+
+[setting.file.option-always-update-links-description]
+original=Turn off to be prompted to update links after renaming a file.
+translation=Sens-it iwakken ad tettwaɛerḍeḍ ɣef uleqqem n yisɣewnen mi ara tbeddleḍ isem n ufaylu.
+
+[setting.file.option-new-note-location]
+original=Default location for new notes
+translation=Adig amezwer n tezmiltin timaynutin
+
+[setting.file.option-new-note-location-description]
+original=Where newly created notes are placed.
+translation=Anda ara ttusrusunt tezmiltin timaynutin ara d-yettwarnan.
+
+[setting.file.option-choice-vault-root]
+original=Vault folder
+translation=Akaram uqenduq
+
+[setting.file.option-choice-current-folder]
+original=Same folder as current file
+translation=D yiwen ukaram am ufaylu amiran
+
+[setting.file.option-choice-specified-folder]
+original=In the folder specified below
+translation=Deg wakaram yettunefken ukessar
+
+[setting.file.option-new-file-folder-path]
+original=Folder to create new notes in
+translation=Akaram anda ara d-ttwarnant tezmiltin timaynutin
+
+[setting.file.option-new-file-folder-path-description]
+original=Newly created notes will appear in this folder.
+translation=Tizmiltin timaynutin ara d-yettwarnan ad d-banent deg wakaram-a.
+
+[setting.file.option-use-wiki-links]
+original=Use [[Wikilinks]]
+translation=Seqdec [[Wikilinks]]
+
+[setting.file.option-use-wiki-links-description]
+original=Auto-generate Wikilinks for [[links]] and ![[images]] instead of Markdown links and images. Disable this option to generate Markdown links instead.
+translation=Sirew s wudem awurman Wikilinks i [[Links]] d ![[images]] deg wemkan n iseɣwan d tugniwin n Markdown. Sens tanefrunt-agi iwakken ad tsireweḍ iseɣwan n Markdown deg umkan-is.
+
+[setting.file.option-show-unsupported-files]
+original=Show all file types
+translation=Sken akk tiwsatin n yifuyla
+
+[setting.file.option-show-unsupported-files-description]
+original=Show files with any extension even if Obsidian can't open them natively, so you can link to them and see them in File Explorer and Quick Switcher.
+translation=Sken ifuyla s yal asiɣzef ɣas ma Obsidian ur yezmir ara ad ten-ildi srid, i wakken ad tizemreḍ ad tcuddeḍ aseɣwen ɣur-sen yerna ad ten-twaliḍ deg unaram n yifuyla d usenfal arurad.
+
+[setting.file.option-links]
+original=Links
+translation=Iseɣwan
+
+[setting.file.option-link-autocompleted-format]
+original=New link format
+translation=Amasal amaynut n useɣwen
+
+[setting.file.option-link-autocompleted-format-description]
+original=What links to insert when auto-generating internal links.
+translation=D acu n yiseɣwan ara tgerreḍ mi ara d-teslaleḍ s wudem awurman iseɣwan igensanen.
+
+[setting.file.option-choice-shortest-linktext]
+original=Shortest path when possible
+translation=Abrid awezlan ma yezmer wamek
+
+[setting.file.option-choice-relative-path]
+original=Path from current file
+translation=Abrid seg ufaylu amiran
+
+[setting.file.option-choice-absolute-path]
+original=Path from vault folder
+translation=Abrid seg ukaram n weḥraz
+
+[setting.file.option-new-attachment-location]
+original=Default location for new attachments
+translation=Adig amezwer i imeddayen imaynuten
+
+[setting.file.option-new-attachment-location-description]
+original=Where newly added attachments are placed.
+translation=Anda ara ttwarennan imeddayen imaynuten.
+[setting.file.option-new-attachment-location-default]
+
+original=Attachments
+translation=Imeddayen
+
+[setting.file.option-choice-subdirectory]
+original=In subfolder under current folder
+translation=Deg udakaram anaddaw ddaw ukaram amiran
+
+[setting.file.option-attachment-folder-path]
+original=Attachment folder path
+translation=Abrid n ukaram umedday
+
+[setting.file.option-attachment-folder-path-description]
+original=Place newly created attachment files, such as images created via drag-and-drop or audio recordings, in this folder.
+translation=Sers ifuyla imaynuten n imeddayen i d-yettunulfan, am tugniwin i d-yettwarnan s uzuγer d trusi neɣ s usekles n yimesli, deg ukaram-a.
+
+[setting.file.option-attachment-subfolder-path]
+original=Subfolder name
+translation=Isem n ukaram anaddaw
+
+[setting.file.option-attachment-subfolder-path-description]
+original=If your file is in “vault/folder”, and you set subfolder name to “attachments”, attachments will be saved to “vault/folder/attachments”.
+translation=Ma yella ufaylu-ineki·nem deg “vault/folder”, yerna terreḍ isem n udakaram d “attachments”, imeddayen ad ttwaḥerzen deg “vault/folder/attachments”.
+
+[setting.file.option-excluded-files]
+original=Excluded files
+translation=Ifuyla yettwastixren
+
+[setting.file.option-excluded-files-desc]
+original=Excluded files will be hidden in Search, Graph View, and Unlinked Mentions, less noticeable in Quick Switcher and link suggestions.
+translation=Ifuyla yettwastixren ad ttwaferren deg Unadi, Taskant n udlif, d tibdarin war aseɣwen, ad qellenn ad ttbanen drus deg Usenfal Arurad d isumar n yiseɣwan.
+
+[setting.file.label-no-excluded-filters-applied]
+original=No excluded filter is applied right now. Add one below.
+translation=Ulac tastayt yettwastixren i yettwasnasen tura. Rnu yiwet ddaw-a.
+
+[setting.file.label-excluded-filters-applied]
+original=Files matching the following filters are currently excluded:
+translation=Ifuyla imṣadan d tistayin-a ttwastixren akka tura:
+
+[setting.file.label-excluded-filter]
+original=Filter
+translation=Tastayt
+
+[setting.file.message-empty-filter]
+original=Filter cannot be empty
+translation=Tastayt ur tezmir ara ad tili d tilemt
+
+[setting.file.placeholder-excluded-filter]
+original=Enter path or “/regex/”...
+translation=Sekcem abrid neɣ “/regex/”...
+
+[setting.file.option-uri-callbacks]
+original=Allow URI callbacks
+translation=Sireg tiɣṛiwin n tuɣalin URI
+
+[setting.file.option-uri-callbacks-desc]
+original=Enable the use of x-callback-url through x-success or x-error when handling Obsidian URIs.
+translation=Sermed aseqdec n x-callback-url s x-success neɣ x-error mi ara tsefrekḍ URI n Obsidian.
+
+[setting.appearance.name]
+original=Appearance
+translation=Timeẓri
+
+[setting.appearance.option-base-theme]
+original=Base color scheme
+translation=Azenziɣ n yini azaduran
+
+[setting.appearance.option-base-theme-description]
+original=Choose Obsidian's default color scheme.
+translation=Fren azenziɣ n yini amezwer n Obsidian.
+
+[setting.appearance.option-accent-color]
+original=Accent color
+translation=Ini n uɣdebbu
+
+[setting.appearance.option-accent-color-description]
+original=Choose the accent color used throughout the app.
+translation=Fren ini n uɣdebbu i yettuseqdacen deg usnas meṛṛa.
+
+[setting.appearance.dark-theme]
+original=Dark
+translation=Ubrik
+
+[setting.appearance.light-theme]
+original=Light
+translation=Aceɛlal
+
+[setting.appearance.system-theme]
+original=Adapt to system
+translation=Sezg ɣer unagraw
+
+[setting.appearance.option-font]
+original=Font
+translation=Tasefsit
+
+[setting.appearance.option-advanced]
+original=Advanced
+translation=Talqayt
+
+[setting.appearance.option-interface]
+original=Interface
+translation=Agrudem
+
+[setting.appearance.option-interface-font]
+original=Interface font
+translation=Tasefsit n ugrudem
+
+[setting.appearance.option-interface-font-description]
+original=Set base font for all of Obsidian.
+translation=Sers tasefsit n uzadur i Obsidian meṛṛa.
+
+[setting.appearance.option-zoom-level]
+original=Zoom level
+translation=Aswir n usemɣer
+
+[setting.appearance.option-zoom-level-description]
+original=Controls the overall zoom level of the app.
+translation=Issenqad aswir n usemɣer amatu n usnas.
+
+[setting.appearance.option-text-font]
+original=Text font
+translation=Tasefsit n weḍris
+
+[setting.appearance.option-text-font-description]
+original=Set font for editing and reading views.
+translation=Sers tasefsit i teẓrigt d tmeẓriwin n tɣuri.
+
+[setting.appearance.option-monospace-font]
+original=Monospace font
+translation=Tasefsit n tallunt tasuft
+
+[setting.appearance.option-monospace-font-description]
+original=Set font for places like code blocks and frontmatter.
+translation=Sers tasefsit i yidgan am yiḥedran n tengalt d tsenṭit.
+
+[setting.appearance.label-single-font-currently-in-effect]
+original= Currently applied font: 
+translation=Tasefsit yettusnasen tura:
+
+[setting.appearance.label-multiple-fonts-currently-in-effect]
+original= The following fonts are currently applied:
+translation=Tisefsiyin-agi ttusnasent tura:
+
+[setting.appearance.option-font-placeholder]
+original=Enter font name...
+translation=Sekcem isem n tsefsit...
+
+[setting.appearance.label-no-custom-font-set]
+original=No custom font is applied right now. Add one below.
+translation=Ulac tasefsit yettusagenen i yettwasnasen tura. Rnu yiwet ddaw-a.
+
+[setting.appearance.label-font-applied]
+original=The first font from this list that is available on your system will be applied.
+translation=Tasefsit tamezwarut seg tebdart-a yellan deg unagraw-ik·im ad tettwasnes.
+
+[setting.appearance.msg-font-not-found]
+original=This font is not detected on your system.
+translation=Tasefsit-a ur tettwafa ara deg unagraw-ik·im.
+
+[setting.appearance.msg-font-found]
+original=This font is detected on your system.
+translation=Tasefsit-a tettwafa deg unagraw-ik·im.
+
+[setting.appearance.label-font-name]
+original=Font name
+translation=Isem n tsefsit
+
+[setting.appearance.option-community-themes]
+original=Community themes
+translation=Isental n temɣiwent
+
+[setting.appearance.option-community-themes-description]
+original=Preview and use amazing themes created by the community.
+translation=Sken yerna seqdec isental igerrzen i d-yenulfan sɣur umɣiwan.
+
+[setting.appearance.button-browse-community-themes]
+original=Browse
+translation=Snirem
+
+[setting.appearance.option-font-size]
+original=Font size
+translation=Tiddi n tsefsit
+
+[setting.appearance.option-font-size-description]
+original=Font size in pixels that affects editing and reading views.
+translation=Tiddi n tsefsit s ipiksilen i yettḥazen asiẓreg d tɣuri.
+
+[setting.appearance.option-font-size-action]
+original=Quick font size adjustment
+translation=Aseggem arurad n tiddi n tsefsit
+
+[setting.appearance.option-font-size-action-description]
+original=Adjust the font size using Ctrl + Scroll, or using the trackpad pinch-zoom gesture.
+translation=Seggem tiddi n tsefsit s useqdec n Ctrl + Adrurem, neɣ s usmussu n usemɣer deg trackpad.
+
+[setting.appearance.option-themes]
+original=Themes
+translation=Isental
+
+[setting.appearance.option-manage-themes-description]
+original=Manage installed themes and browse community themes.
+translation=Sefrek isental yettwasbedden akked isental n umɣiwan.
+
+[setting.appearance.option-theme-button-manage]
+original=Manage
+translation=Sefrek
+
+[setting.appearance.option-choice-none]
+original=None
+translation=Ulac
+
+[setting.appearance.option-native-menus]
+original=Native menus
+translation=Umuɣen inaṣliyen
+
+[setting.appearance.option-native-menus-desc]
+original=Menus throughout the app will match the operating system. They will not be affected by your theme.
+translation=Umuɣen deg usnas meṛṛa ad mṣadan d unagraw n wammud. Ur ttwaḥazen ara s usentel-ik·im.
+
+[setting.appearance.button-reload-themes]
+original=Reload themes
+translation=Ales asali n isental
+
+[setting.appearance.msg-reloaded-themes]
+original=Reloaded custom CSS themes.
+translation=Yettwales usali n isental CSS yettusagenen.
+
+[setting.appearance.button-open-themes-folder]
+original=Open themes folder
+translation=Ldi akaram n isental
+
+[setting.appearance.option-css-snippets]
+original=CSS snippets
+translation=Iḥricen CSS
+
+[setting.appearance.label-no-css-snippets-found]
+original=No CSS snippets found.
+translation=Ulac iḥricen CSS i yettwafan.
+
+[setting.appearance.no-snippet-description]
+original=CSS Snippets are stored in “{{path}}”.
+translation=Iḥricen CSS ttwaḥerzen deg “{{path}}”.
+
+[setting.appearance.button-reload-snippets]
+original=Reload snippets
+translation=Ales asali n yiḥricen
+
+[setting.appearance.button-open-snippets-folder]
+original=Open snippets folder
+translation=Ldi akaram n yiḥricen
+
+[setting.appearance.msg-reloaded-snippets]
+original=Reloaded CSS snippets.
+translation=Yettwales usali n yiḥricen CSS.
+
+[setting.appearance.option-toggle-snippet-description]
+original=Apply CSS snippet at “{{path}}”.
+translation=Snes aḥric CSS deg “{{path}}”.
+
+[setting.appearance.label-installed-themes]
+original=Installed themes
+translation=Isental yettwasbedden
+
+[setting.appearance.label-screenshot-unavailable]
+original=Screenshot unavailable
+translation=Tuṭṭfa n ugdil ur tewjid ara
+
+[setting.appearance.label-default-theme]
+original=Default
+translation=Amezwer
+
+[setting.appearance.tooltip-click-to-enlarge]
+original=Click to enlarge
+translation=Sit i wakken ad tsemɣereḍ
+
+[setting.appearance.button-update]
+original=Update
+translation=Mucceḍ
+
+[setting.appearance.label-currently-active]
+original=Active
+translation=Urmid
+
+[setting.appearance.option-frame-style]
+original=Window frame style
+translation=Aɣanib n ukatar n usfaylu
+
+[setting.appearance.option-frame-description]
+original=Determines the styling of the title bar of Obsidian windows. Requires a full restart to take effect.
+translation=Isbadu aɣanib n tfeggagt n uzwel n yisfuyla n Obsidian. Yeḥwaǧ allus n usekker ummid i wakken ad yettwasnes.
+
+[setting.appearance.option-frame-hidden]
+original=Hidden (default)
+translation=Uffir (amezwer)
+
+[setting.appearance.option-frame-obsidian]
+original=Obsidian frame
+translation=Akatar n Obsidian
+
+[setting.appearance.option-frame-native]
+original=Native frame
+translation=Akatar anaṣli
+
+[setting.appearance.option-custom-icon]
+original=Custom app icon
+translation=Tignit n usnas yugnen
+
+[setting.appearance.option-custom-icon-desc]
+original=Set a custom icon for the app
+translation=Sbadu tignit yugnen i usnas
+
+[setting.appearance.button-choose-custom-icon]
+original=Choose custom icon
+translation=Fren tignit yettusagenen
+
+[setting.appearance.option-configure-ribbon]
+original=Ribbon menu configuration
+translation=Tawila n umuɣ n tesfift
+
+[setting.appearance.option-configure-ribbon-desc]
+original=Configure what commands appear in the ribbon menu.
+translation=Swel tiludna ara d-yebbanen deg umuɣ n tesfift
+
+[setting.appearance.option-mobile-quick-ribbon-item]
+original=Quick access ribbon item
+translation=Anekcum arurad ɣer ferdis n tesfift
+
+[setting.appearance.option-mobile-quick-ribbon-item-desc]
+original=Choose the behavior of tapping the ribbon button in the navigation menu. By default, this will open a menu showing all your ribbon items.
+translation=Fren tikli n tussda ɣef tqeffalt n tesfift deg umuɣ n tunigin. S unezwer, aya ad yeldi amuɣ yeskanayen akk iferdisen-ik·im n tesfift.
+
+[setting.appearance.option-mobile-quick-ribbon-default]
+original=Open ribbon menu
+translation=Ldi amuɣ n tesfift
+
+[setting.appearance.button-configure]
+original=Configure
+translation=Swel
+
+[setting.appearance.option-show-ribbon]
+original=Show ribbon
+translation=Sken tasfift
+
+[setting.appearance.option-show-ribbon-desc]
+original=Display vertical toolbar on the side of the window.
+translation=Sken afeggag n yifecka ubdid ɣer yidis n usfaylu.
+
+[setting.appearance.label-additional-ribbon-items]
+original=Other ribbon items
+translation=Iferdisen-nniḍen n tesfift
+
+[setting.appearance.label-modal-configuration]
+original=Ribbon menu
+translation=Amuɣ n tesfift
+
+[setting.appearance.label-modal-configuration-desc]
+original=Choose what items you want to be active in the ribbon. Drag and drop to change the order.
+translation=Fren iferdisen i tebɣiḍ ad ilin remden deg tesfift. Zuɣeṛ yerna sers i wakken ad tbeddleḍ amizzwer.
+
+[setting.appearance.option-show-view-header]
+original=Show tab title bar
+translation=Sken afeggag n uzwel n yiccer
+
+[setting.appearance.option-show-view-header-desc]
+original=Display the header at the top of every tab.
+translation=Sken tasenṭit ufella n yal iccer.
+
+[setting.appearance.option-floating-navigation]
+original=Floating navigation
+translation=Tunigin yettifliwen
+
+[setting.appearance.option-floating-navigation-desc]
+original=Navigation buttons float over the content instead of being anchored.
+translation=Tiqeffalin n tunigin yettifliwen sennig ugbur deg wadeg ad ttwasṭefent.
+
+[setting.appearance.option-sliding-sidebar]
+original=Sliding sidebars
+translation=Ifeggagin idisanen yettecḍen
+
+[setting.appearance.option-sliding-sidebar-desc]
+original=Sidebars slide to the side of the content instead of floating above.
+translation=Ifeggagin idisanen yettecḍen ɣer yidis n ugbur deg wadeg ad yettifliwen sennig-s.
+
+[setting.appearance.option-auto-full-screen]
+original=Full screen
+translation=Agdil ummid
+
+[setting.appearance.option-auto-full-screen-desc]
+original=Automatically hide interface elements while reading.
+translation=Ffer s wudem awurman iferdisen n ugrudem mi ara teqqareḍ.
+
+[setting.appearance.msg-updates-found]
+original=Found {{count}} theme to update.
+translation=Yettwafa {{count}} n usentel i umucceḍ.
+
+[setting.appearance.msg-updates-found_plural]
+original=Found {{count}} themes to update.
+translation=Ttwafan {{count}} n isental i umucceḍ.
+
+[setting.appearance.button-check-for-updates]
+original=Check for updates
+translation=Senqed imuccḍen
+
+[setting.appearance.button-view-updates]
+original=View updates
+translation=Sken imuccḍen
+
+[setting.appearance.button-update-all-themes]
+original=Update all
+translation=Mucceḍ akk
+
+[setting.appearance.label-current-themes]
+original=Current community themes
+translation=Isental n umɣiwan imiranen
+
+[setting.appearance.label-currently-installed]
+original=You currently have {{count}} theme installed.
+translation=Tesɛiḍ tura {{count}} n usentel yettwasbedden.
+
+[setting.appearance.label-currently-installed_plural]
+original=You currently have {{count}} themes installed.
+translation=Tesɛiḍ tura {{count}} n isental yettwasbedden.
+
+[setting.hotkeys.name]
+original=Hotkeys
+translation=Tiqeffalin n unegzum
+
+[setting.hotkeys.option-search]
+original=Search hotkeys
+translation=Nadi tiqeffalin n unegzum
+
+[setting.hotkeys.option-search-desc]
+original=Showing {{count}} hotkey. 
+translation=Yeskanay-d {{count}} tqeffalt n unegzum. 
+
+[setting.hotkeys.option-search-desc_plural]
+original=Showing {{count}} hotkeys. 
+translation=Yeskanay-d {{count}} tiqeffalin n unegzum. 
+
+[setting.hotkeys.option-search-conflict]
+original={{count}} command with conflicts.
+translation={{count}} n tladna s ccwal.
+
+[setting.hotkeys.option-search-conflict_plural]
+original={{count}} commands with conflicts.
+translation={{count}} n tludna s ccwal.
+
+[setting.hotkeys.prompt-filter]
+original=Filter...
+translation=Tastayt...
+
+[setting.hotkeys.tooltip-delete-hotkey]
+original=Delete hotkey
+translation=Kkes taqeffalt n unegzum
+
+[setting.hotkeys.label-waiting-for-hotkey-press]
+original=Press hotkey...
+translation=Sit ɣef tqeffalt n unegzum...
+
+[setting.hotkeys.label-show-all]
+original=All
+translation=Akk
+
+[setting.hotkeys.label-show-unassigned]
+original=Unassigned
+translation=Ur yettwasdukel ara
+
+[setting.hotkeys.label-show-assigned]
+original=Assigned
+translation=Yettwasdukel
+
+[setting.hotkeys.label-show-user-assigned]
+original=Assigned by me
+translation=Yettwasdukel sɣur nekk
+
+[setting.hotkeys.tooltip-restore-default]
+original=Restore default
+translation=Err-d amezwer
+
+[setting.hotkeys.tooltip-customize-command]
+original=Customize this command
+translation=Sagen taladna-a
+
+[setting.hotkeys.tooltip-hotkey-single-conflict]
+original=This hotkey conflicts with “{{command}}”
+translation=Taqeffalt-a n unegzum tesɛa ccwal d “{{command}}”
+
+[setting.hotkeys.tooltip-hotkey-multiple-conflicts]
+original=This hotkey conflicts with {{count}} other commands
+translation=Taqeffalt-a n unegzum tesɛa ccwal d {{count}} n tludna-nniḍen
+
+[setting.hotkeys.label-blank-hotkey]
+original=Blank
+translation=Ilem
+
+[setting.keychain.name]
+original=Keychain
+translation=Azrar n tsura
+
+[setting.keychain.secrets]
+original=Secrets
+translation=Uffiren
+
+[setting.keychain.action-add-secret]
+original=Add secret
+translation=Rnu uffir
+
+[setting.keychain.action-edit-secret]
+original=Edit secret
+translation=Ẓreg uffir
+
+[setting.keychain.action-show-secret-value]
+original=Show secret
+translation=Sken uffir
+
+[setting.keychain.action-hide-secret-value]
+original=Hide secret
+translation=Ffer uffir
+
+[setting.keychain.label-secret-id]
+original=ID
+translation=Asulay
+
+[setting.keychain.label-secret-value]
+original=Secret
+translation=Uffir
+
+[setting.keychain.placeholder-secret-id]
+original=secret-name
+translation=isem-uffir
+
+[setting.keychain.option-secret-id-description]
+original=Lowercase letters, numbers and dashes only.
+translation=Isekkilen imeẓyanen, imḍanen d yijerriden kan.
+
+[setting.keychain.option-secret-value-description]
+original=Enter your secret.
+translation=Sekcem uffir-inek·inem.
+
+[setting.keychain.msg-never-accessed]
+original=Never accessed
+translation=Werǧin yettwaddef
+
+[setting.keychain.msg-error-update-secret]
+original=Failed to update secret.
+translation=Yecceḍ umucceḍ n uffir.
+
+[setting.keychain.msg-error-add-secret]
+original=Failed to add secret.
+translation=Yecceḍ wernuy n uffir.
+
+[setting.keychain.msg-error-secret-id-exists]
+original=A secret with this ID already exists.
+translation=Uffir s usulay-a yella yakan.
+
+[setting.keychain.msg-error-secret-value-empty]
+original=Secret value cannot be empty.
+translation=Azal n uffir ur yezmir ara ad yili d ilem.
+
+[setting.keychain.msg-error-secret-id-invalid]
+original=Secret ID is invalid. Use only lowercase letters, numbers and dashes. 64 characters max.
+translation=Asulay n uffir yecceḍ. Seqdec kan isekkilen imeẓyanen, imḍanen d yijerriden. 64 isekkilen s wudem afellay.
+
+[setting.keychain.keychain-empty-state]
+original=No secrets have been added. Secrets are used to store information like API keys and passwords that plugins can use.
+translation=Ulac uffiren i yettwarnan. Uffiren ttuseqdacen i weḥraz n talɣut am tsura API d wawalen n uɛeddi i zemren ad seqdcen yisiɣzaf.
+
+[setting.keychain.label-select-secret]
+original=Select secret
+translation=Fren uffir
+
+[setting.keychain.placeholder-search-secret]
+original=Find secret...
+translation=Af-d uffir...
+
+[setting.keychain.button-add-secret]
+original=Add secret...
+translation=Rnu uffir...
+
+[setting.keychain.button-link]
+original=Link...
+translation=Aseɣwen...
+
+[setting.keychain.msg-secrets-not-encrypted]
+original=Secrets are stored without encryption because no secret store is available on this system.
+translation=Uffiren ttwaḥerzen war awgelhen acku ulac aḥraz n uffir i yellan deg unagraw-a.
+
+[setting.keychain.msg-secrets-not-encrypted-short]
+original=Secrets are not encrypted
+translation=Uffiren ur ttwagelhenen ara
+
+[setting.keychain.button-dismiss-warning]
+original=Don't show again
+translation=Ur skanay ara tikkelt nniḍen
+
+[setting.keychain.label-encryption-not-available]
+original=Encryption not available
+translation=Awgelhen ur yella ara
+
+[setting.keychain.msg-encryption-provided-by-o-s]
+original=Encryption is provided by your operating system's secret store. Without a secret store, your secrets will be stored without encryption.
+translation=Awgelhen yettunefk-d sɣur weḥraz n uffiren n unagraw n wammud-inek·inem. Mebla aḥraz n uffiren, uffiren-ik·im ad ttwaḥerzen war awgelhen.
+
+[setting.keychain.msg-linux-secret-stores]
+original=On Linux, supported secret stores include:
+translation=Deg Linux, iḥrazen n uffiren yettusefraken d wi:
+
+[setting.about.name]
+original=General
+translation=Amatu
+
+[setting.about.label-commercial-license]
+original=Commercial license
+translation=Turagt tamzenzit 
+
+[setting.about.label-license-key]
+original=License key
+translation=Tasarut n turagt
+
+[setting.about.license-key-placeholder]
+original=Your license key...
+translation=Tasarut-ik·im n turagt...
+
+[setting.about.label-activate-license]
+original=Activate license
+translation=Sermed turagt
+
+[setting.about.button-activate]
+original=Activate
+translation=Sermed
+
+[setting.about.label-unknown-version]
+original=Unknown
+translation=Ur yettwassen ara
+
+[setting.about.label-version]
+original=Version {{version}}
+translation=Lqem {{version}}
+
+[setting.about.label-install-version]
+original=Installer version: {{version}}
+translation=Lqem n umsebded: {{version}}
+
+[setting.about.label-read-changelog]
+original=Read the changelog.
+translation=Ɣer aɣmis n yibeddilen.
+
+[setting.about.label-manual-update-required]
+original=To support the latest features and to receive the latest security patches, Obsidian needs a major installer update. You need to manually download and reinstall Obsidian.
+translation=I wakken ad isefrek timahilin tineggura daɣen ad d-remseḍ ikemmusen n tɣellist ineggura, Obsidian yeḥwaǧ amucceḍ ameqran n umsebded. Teḥwaǧeḍ ad tsidreḍ yerna ad tesbeddeḍ Obsidian tikkelt nniḍen s ufus.
+
+[setting.about.label-new-version-ready]
+original=A new version is ready to be installed. 
+translation=Lqem amaynut ihegga i usbeddi. 
+
+[setting.about.label-disabled-updates]
+original=Updates are disabled.
+translation=Imuccḍen ttwassensen.
+
+[setting.about.button-relaunch]
+original=Relaunch
+translation=Ales asekker
+
+[setting.about.button-check-for-updates]
+original=Check for updates
+translation=Senqed imuccḍen
+
+[setting.about.option-auto-update]
+original=Automatic updates
+translation=Imuccḍen iwurmanen
+
+[setting.about.option-auto-update-description]
+original=Turn this off to prevent the app from checking for updates.
+translation=Ssens aya i wakken ad tsewḥeleḍ asnas seg usenqed n yimuccḍen.
+
+[setting.about.option-check-slow-startup]
+original=Notify if startup takes longer than expected
+translation=Mel-d ma yella asekker yeṭṭef akud ugar n wayen yetturaǧun
+
+[setting.about.option-check-slow-startup-description]
+original=Diagnose issues with your app by seeing what is causing the app to load slowly.
+translation=Eg tawassna i wuguren deg usnas-ik·im s tmuɣli ɣer wayen yettarran asnas yettali-d ẓẓay.
+
+[setting.about.button-check-startup]
+original=Check now
+translation=Senqed tura
+
+[setting.about.option-cli]
+original=Command line interface
+translation=Agrudem n yizirig n tladna
+
+[setting.about.option-cli-description]
+original=Allow interactions with Obsidian from the command line.
+translation=Sireg timyigawin d Obsidian seg yizirig n tladna.
+
+[setting.about.option-register-path]
+original=Set up CLI to work in the terminal
+translation=Sbedd CLI i wakken ad ixeddem deg yixf
+
+[setting.about.option-register-path-description]
+original=Register "obsidian" in PATH to enable accessing the "obsidian" command anywhere from your terminal.
+translation=Jerred "obsidian" deg ubrid (PATH) i wakken ad tsirgeḍ addaf ɣer tladna "obsidian" seg yal amkan deg yixf-ik·im.
+
+[setting.about.button-register]
+original=Register
+translation=Jerred
+
+[setting.about.option-get-help]
+original=Help
+translation=Tallalt
+
+[setting.about.option-get-help-description]
+original=Learn how to use Obsidian and get help from the community.
+translation=Lmed amek ara tseqdceḍ Obsidian yerna awi-d tallalt seg umɣiwan.
+
+[setting.about.button-open]
+original=Open
+translation=Ldi
+
+[setting.about.option-language]
+original=Language
+translation=Tutlayt
+
+[setting.about.option-language-description]
+original=Change the display language.
+translation=Beddel tutlayt n uskan.
+
+[setting.about.option-insider-build]
+original=Receive early access versions
+translation=Rmes ileqman n waddaf zik
+
+[setting.about.option-insider-build-description]
+original=Auto-update to the latest early access version. These versions include new features but may be less stable.
+translation=Mucceḍ s wudem awurman ɣer lqem aneggaru n waddaf zik. Ileqman-a deg-sen timahilin timaynutin maca zemren ur ttarkaden ara aṭas.
+
+[setting.about.option-advanced]
+original=Advanced
+translation=Talqayt
+
+[setting.about.option-hw-acceleration]
+original=Hardware acceleration
+translation=Asɣiwel n warrum
+
+[setting.about.option-hw-acceleration-description]
+original=Turns on Hardware Acceleration, which uses your GPU to make Obsidian smoother.
+translation=Rmed asɣiwel n warrum, ayen iseqdacen GPU-ik·im i wakken ad yerr Obsidian d alqaq (fessus).
+
+[setting.about.option-hw-acceleration-warning]
+original=If you turn this off, app performance will be severely degraded.
+translation=Ma tessenseḍ aya, tamellit n usnas ad xuṣṣ aṭas.
+
+[setting.about.option-config-location]
+original=Override config folder
+translation=Semselsi akaram n twila
+
+[setting.about.option-config-location-description]
+original=Use a different config folder than the default one. Must start with a dot.
+translation=Seqdec akaram n twila yemgaraden ɣef win n umezwer. Ilaq ad yebdu s tneqqiṭ.
+
+[setting.about.option-config-location-warning]
+original=Config location must be a valid folder name that starts with a dot.
+translation=Ideg n twila ilaq ad yili d isem ameɣtu n ukaram i yebeddun s tneqqiṭ.
+
+[setting.about.label-license]
+original=License
+translation=Turagt
+
+[setting.about.label-your-commercial-license-key]
+original=Your commercial license key is “{{key}}”.
+translation=Tasarut-inek·inem n turagt tamzenzit d “{{key}}”.
+
+[setting.about.label-commercial-license-info]
+original=Registered to “{{company}}” for {{seats}} users. Valid until {{expiry}}.
+translation=Ijerred ɣef “{{company}}” i {{seats}} n iseqdacen. D ameɣtu ar {{expiry}}.
+
+[setting.about.label-validating-commercial-license]
+original=Validating...
+translation=Aseɣbel...
+
+[setting.about.label-invalid-commercial-license]
+original=License invalid: 
+translation=Turagt ur teɣbil ara: 
+
+[setting.about.button-remove-commercial-license]
+original=Remove
+translation=Kkes
+
+[setting.about.option-catalyst]
+original=Catalyst license
+translation=Turagt Catalyst
+
+[setting.about.option-catalyst-desc]
+original=You currently have the {{tier}} Catalyst license. Thanks for your support!
+translation=Tesɛiḍ tura turagt Catalyst n weswir {{tier}}. Tanemmirt ɣef tallalt-inek!
+
+[setting.about.option-catalyst-desc-no-license]
+original=You don't have a Catalyst license. Catalyst is a one-time donation that helps Obsidian remain 100% user-supported and gives you early access to new features.
+translation=Ur tesɛiḍ ara turagt Catalyst. Catalyst d tikci n yiwet n tikkelt i yettallalen Obsidian ad yeqqim yettwallel 100% sɣur iseqdacen yerna ad ak-d-yefk addaf zik ɣer tmahilin timaynutin.
+
+[setting.about.label-app]
+original=App
+translation=Asnas
+
+[setting.about.label-add-own-language]
+original=Learn how to add a new language to Obsidian.
+translation=Lmed amek ara ternuḍ tutlayt tamaynut i Obsidian.
+
+[setting.account.name]
+original=Account
+translation=Amiḍan
+
+[setting.account.option-your-account]
+original=Your account
+translation=Amiḍan-ik·im
+
+[setting.account.option-your-account-desc]
+original=You're currently signed in as {{name}} ({{email}}).
+translation=Tkecmeḍ tura s yisem n {{name}} ({{email}}).
+
+[setting.account.option-your-account-desc-no-login]
+original=You're not logged in right now. An account is only needed for Obsidian Sync, Obsidian Publish, and early access versions.
+translation=Ur tkicmeḍ ara tura. Amiḍan yettwaḥwaǧ kan i umtawi Obsidian, Tasuffeɣt Obsidian, d yileqman n waddaf zik.
+
+[setting.account.button-upgrade-catalyst]
+original=Upgrade
+translation=Sali aswir n leqqem
+
+[setting.account.option-commercial-license]
+original=Commercial license
+translation=Turagt tamzenzit
+
+[setting.account.option-commercial-license-desc]
+original=Help keep Obsidian 100% user-supported.
+translation=Mudd afus i wakken Obsidian ad yeqqim yettwallel 100% sɣur iseqdacen.
+
+[setting.account.button-purchase]
+original=Purchase
+translation=Aɣ
+
+[setting.account.button-log-out]
+original=Log out
+translation=Ffeɣ
+
+[setting.account.label-log-in]
+original=Log in
+translation=Kcem
+
+[setting.account.label-sign-up]
+original=Sign up
+translation=Jerred
+
+[setting.account.label-email]
+original=Email
+translation=Imayl
+
+[setting.account.placeholder-email]
+original=Your email...
+translation=Imayl-ik·im...
+
+[setting.account.label-name]
+original=Full name
+translation=Isem ummid
+
+[setting.account.label-password]
+original=Password
+translation=Awal n uɛeddi
+
+[setting.account.placeholder-password]
+original=Your password...
+translation=Awal-ik·im n uɛeddi...
+
+[setting.account.label-forgot-password]
+original=Forgot password?
+translation=Tettuḍ awal n uɛeddi?
+
+[setting.account.button-login]
+original=Login
+translation=Kcem
+
+[setting.account.message-empty-email]
+original=Email cannot be empty.
+translation=Imayl ur yezmir ara ad yili d ilem.
+
+[setting.account.message-invalid-email]
+original=Email is not valid.
+translation=Imayl ur yeɣbil ara.
+
+[setting.account.message-empty-password]
+original=Password cannot be empty.
+translation=Awal n uɛeddi ur yezmir ara ad yili d ilem.
+
+[setting.account.message-login-failed]
+original=Login failed, please double check your email and password.
+translation=Anekcum yecceḍ, ttxil-k·m senqed imayl d wawal-ik·im n uɛeddi.
+
+[setting.account.message-signup-failed]
+original=Failed to sign up
+translation=Yecceḍ ujerred
+
+[setting.account.label-no-account]
+original=Don't have an account? 
+translation=Ur tesɛiḍ ara amiḍan? 
+
+[setting.account.link-sign-up-now]
+original=Sign up now
+translation=Jerred tura
+
+[setting.account.label-mfa-code]
+original=6-digit 2FA code
+translation=Tangalt 2FA n 6 n yizwilen
+
+[setting.account.mfa-wrong-format]
+original=The 2FA authenticator code must be 6 digits.
+translation=Tangalt n usesteb 2FA ilaq ad tesɛu 6 n yizwilen.
+
+[setting.account.mfa-verification-failed]
+original=2FA code is incorrect, please double check your authenticator app.
+translation=Tangalt 2FA tecceḍ, ttxil-k·m senqed asnas-ik·im n usesteb.
+
+[setting.core-plugin.plugin-list]
+original=Plugin list
+translation=Tabdart n yisiɣzaf
+
+[setting.core-plugin.option-search-plugin]
+original=Search core plugins
+translation=Nadi isiɣzaf igejdayen
+
+[setting.core-plugin.option-search-plugin-description]
+original=Filter plugins by name or description.
+translation=Sti isiɣzaf s yisem neɣ aglam.
+
+[setting.core-plugin.placeholder-search-plugin]
+original=Search plugins...
+translation=Nadi isiɣzaf...
+
+[setting.third-party-plugin.name]
+original=Community plugins
+translation=Isiɣzaf n umɣiwan
+
+[setting.third-party-plugin.option-restricted-mode]
+original=Restricted mode
+translation=Askar ukrif
+
+[setting.third-party-plugin.option-restricted-mode-description]
+original=Restricted mode is off. Turn on to disable community plugins.
+translation=Askar ukrif yensa. Sermed-it i wakken ad tessenseḍ isiɣzaf n umɣiwan.
+
+[setting.third-party-plugin.button-turn-on]
+original=Turn on and reload
+translation=Sermed yerna ales asali
+
+[setting.third-party-plugin.option-automatic-update-check]
+original=Automatically check for plugin updates
+translation=Senqed s wudem awurman imuccḍen n yisiɣzaf
+
+[setting.third-party-plugin.option-automatic-update-check-desc]
+original=Periodically check for plugin updates.
+translation=Senqed s wudem awalan imuccḍen n yisiɣzaf.
+
+[setting.third-party-plugin.option-browse-community-plugins]
+original=Community plugins
+translation=Isiɣzaf n umɣiwan
+
+[setting.third-party-plugin.option-browse-community-plugins-description]
+original=Browse and install community plugins made by our amazing community.
+translation=Snirem yerna sbedd isiɣzaf n umɣiwan i d-yesnulfa umɣiwan-nneɣ igerrzen.
+
+[setting.third-party-plugin.button-browse]
+original=Browse
+translation=Snirem
+
+[setting.third-party-plugin.label-exit-restricted-mode]
+original=Exit Restricted Mode
+translation=Ffeɣ seg Uskar Ukrif
+
+[setting.third-party-plugin.label-exit-restricted-mode-description-1]
+original=Community plugins, like any other software you install, could potentially cause data integrity and security issues.
+translation=Isiɣzaf n umɣiwan, am yal aseɣẓan nniḍen ara tesbeddeḍ, zemren ad d-glun s uguren n timmad n yisefka d tɣellist.
+
+[setting.third-party-plugin.label-exit-restricted-mode-description-2]
+original=Plugin security is important to us. Here's what we do:
+translation=Taɣellist n yisiɣzaf d ayen yesɛan azal ɣur-nneɣ. Atan wayen nxeddem:
+
+[setting.third-party-plugin.label-exit-restricted-mode-description-3]
+original=Despite our efforts, there is still a small chance that a community plugin might misbehave.
+translation=Ɣas akken nxeddem ayen iwumi nezmer, yezmer lḥal kra n usiɣzef n umɣiwan ad yexdem annect ur nelhi.
+
+[setting.third-party-plugin.label-code-review]
+original=Initial code review
+translation=Asenqed amezwaru n tengalt
+
+[setting.third-party-plugin.label-code-review-desc]
+original=Plugins in the official community directory undergo an initial code review by our team before they are listed.
+translation=Isiɣzaf deg ukaram amɣiwan unṣib ttɛeddin ɣef usenqed amezwaru n tengalt sɣur tarbaɛt-nneɣ uqbel ad ttwabedren.
+
+[setting.third-party-plugin.label-open-source]
+original=Open source
+translation=Aɣbalu yeldin
+
+[setting.third-party-plugin.label-open-source-desc]
+original=Most plugins are open source on GitHub, so you can inspect the code yourself.
+translation=Aṭas n yisiɣzaf sɛan aɣbalu yeldin deg GitHub, ihi tzemreḍ ad tsenqdeḍ tangalt s yiman-ik·im.
+
+[setting.third-party-plugin.label-peer-audit]
+original=Peer audit
+translation=Amselken ger iyuganen
+
+[setting.third-party-plugin.label-peer-audit-desc]
+original=We have a large community of developers who watch out for each other.
+translation=Nesɛa amɣiwan ameqran n yineflayen i yettḥadaren wa ɣef wa.
+
+[setting.third-party-plugin.label-report-mechanism]
+original=Report mechanism
+translation=Tarrayt n walɣu
+
+[setting.third-party-plugin.label-report-mechanism-desc]
+original=We follow up and remove faulty plugins upon user report.
+translation=Nettḍafaṛ yerna nettekkes isiɣzaf ixuṣṣen mi ara d-yili walɣu sɣur useqdac.
+
+[setting.third-party-plugin.label-exit-restricted-mode-disable-confirmation]
+original=Would you like to exit Restricted Mode to enable community plugins? We strongly recommend making backups of your data before doing so.
+translation=Tebɣiḍ ad teffɣeḍ seg Uskar Ukrif i wakken ad tsermdeḍ isiɣzaf n umɣiwan? Nweṣṣa-k·m aṭas ad txedmeḍ iḥrazen i yisefka-ik·im uqbel ad texedmeḍ aya.
+
+[setting.third-party-plugin.label-learn-more]
+original=Learn more about plugin security
+translation=Lmed ugar ɣef tɣellist n yisiɣzaf
+
+[setting.third-party-plugin.button-turn-on-community-plugins]
+original=Turn on community plugins
+translation=Sermed isiɣzaf n umɣiwan
+
+[setting.third-party-plugin.label-trust-author]
+original=Do you trust the author of this vault?
+translation=Tettamneḍ ameskar n ukaram-a n weḥraz?
+
+[setting.third-party-plugin.label-trust-author-description-1]
+original=You're opening this vault for the first time, and it comes with some plugins.
+translation=Telliḍ akaram-a n weḥraz i tikkelt tamezwarut, yerna yusa-d s kra n yisiɣzaf.
+
+[setting.third-party-plugin.label-trust-author-description-2]
+original=If you obtained this vault from someone else, please note that plugins of unknown origin might pose security risks.
+translation=Ma tewwiḍ-d akaram-a n weḥraz sɣur wemdan nniḍen, ḥṣu belli isiɣzaf i wumi ur yettwassen ara uɣbalu zemren ad d-awin iqemmṛen n tɣellist.
+
+[setting.third-party-plugin.label-trust-author-description-3]
+original=If you do not fully trust the author of this vault, we recommend staying in Restricted Mode, so the plugins in this vault do not run.
+translation=Ma ur tettamneḍ ara s wudem ummid ameskar n ukaram-a n weḥraz, nweṣṣa-k·m ad teqqimeḍ deg Uskar Ukrif, i wakken isiɣzaf yellan deg ukaram-a n weḥraz ur selkamen ara.
+
+[setting.third-party-plugin.button-enable-plugins]
+original=Trust author and enable plugins
+translation=Amen ameskar yerna sermed isiɣzaf
+
+[setting.third-party-plugin.button-dont-trust-author]
+original=Browse vault in Restricted Mode
+translation=Snirem akaram n weḥraz deg Uskar Ukrif
+
+[setting.third-party-plugin.placeholder-community-plugins]
+original=Search community plugins...
+translation=Nadi isiɣzaf n umɣiwan...
+
+[setting.third-party-plugin.msg-failed-load-plugins]
+original=Failed to load community plugins.
+translation=Yecceḍ usali n yisiɣzaf n umɣiwan.
+
+[setting.third-party-plugin.label-installed]
+original=Installed
+translation=Yettwasbedd
+
+[setting.third-party-plugin.button-install]
+original=Install
+translation=Sbedd
+
+[setting.third-party-plugin.button-enable]
+original=Enable
+translation=Sermed
+
+[setting.third-party-plugin.button-disable]
+original=Disable
+translation=Ssens
+
+[setting.third-party-plugin.button-copy-share-link]
+original=Copy share link
+translation=Nɣel aseɣwen n beṭṭu
+
+[setting.third-party-plugin.button-donate]
+original=Donate
+translation=Mudd tawsa
+
+[setting.third-party-plugin.label-no-results-found]
+original=No results found.
+translation=Ulac igmaḍ i yettwafan.
+
+[setting.third-party-plugin.label-no-recent-files-found]
+original=No recent files found. Type to search...
+translation=Ulac ifuyla n melmi kan i yettwafan. Aru i wakken ad tnadiḍ...
+
+[setting.third-party-plugin.msg-failed-to-load-manifest]
+original=Failed to load plugin manifest.
+translation=Yecceḍ usali n umeskan n usiɣzef.
+
+[setting.third-party-plugin.label-version]
+original=Version: {{version}}
+translation=Lqem: {{version}}
+
+[setting.third-party-plugin.label-currently-installed-version]
+original= (currently installed: {{version}})
+translation= (yettwasbedd tura: {{version}})
+
+[setting.third-party-plugin.label-by-author]
+original=By 
+translation=Sɣur 
+
+[setting.third-party-plugin.label-repository]
+original=Repository: 
+translation=Akufi: 
+
+[setting.third-party-plugin.label-last-update]
+original=Last update: 
+translation=Amucceḍ aneggaru: 
+
+[setting.third-party-plugin.tooltip-view-last-update]
+original=View the latest update
+translation=Sken amucceḍ aneggaru
+
+[setting.third-party-plugin.label-unsupported]
+original=This plugin does not support your device.
+translation=Asiɣzef-a ur isefrak ara ibenk-ik·im.
+
+[setting.third-party-plugin.button-update]
+original=Update
+translation=Mucceḍ
+
+[setting.third-party-plugin.label-no-readme]
+original=This plugin did not provide a README file.
+translation=Asiɣzef-a ur d-yefki ara afaylu README.
+
+[setting.third-party-plugin.msg-installing-plugin]
+original=Installing plugin “{{name}}”...
+translation=Asbeddi n usiɣzef “{{name}}”...
+
+[setting.third-party-plugin.msg-failed-to-install-plugin]
+original=Failed to install plugin “{{name}}”.
+translation=Yecceḍ usbeddi n usiɣzef “{{name}}”.
+
+[setting.third-party-plugin.msg-successfully-installed-plugin]
+original=Successfully installed plugin “{{name}}”.
+translation=Asbeddi n usiɣzef “{{name}}” yedda.
+
+[setting.third-party-plugin.msg-failed-to-uninstall-plugin]
+original=Failed to uninstall plugin “{{id}}”.
+translation=Tecceḍ tukksa n usiɣzef “{{id}}”.
+
+[setting.third-party-plugin.msg-failed-to-disable-plugin]
+original=Failed to disable plugin “{{id}}”.
+translation=Yecceḍ usensi n usiɣzef “{{id}}”.
+
+[setting.third-party-plugin.label-installed-plugins]
+original=Installed plugins
+translation=Isiɣzaf yettwasbedden
+
+[setting.third-party-plugin.button-reload-plugins]
+original=Reload plugins
+translation=Ales asali n yisiɣzaf
+
+[setting.third-party-plugin.msg-reloaded-third-party-plugins]
+original=Reloaded third-party plugins.
+translation=Yettwales usali n yisiɣzaf n wis kraḍ.
+
+[setting.third-party-plugin.label-uninstall]
+original=Uninstall
+translation=Kkes
+
+[setting.third-party-plugin.label-uninstall-plugin]
+original=Uninstall plugin
+translation=Kkes asiɣzef
+
+[setting.third-party-plugin.label-uninstall-plugin-confirmation]
+original=Are you sure you want to uninstall this plugin? This will delete the folder of the plugin.
+translation=Tebɣiḍ s tidet ad tekksed asiɣzef-a? Aya ad yekkes akaram n usiɣzef.
+
+[setting.third-party-plugin.button-open-plugins-folder]
+original=Open plugins folder
+translation=Ldi akaram n yisiɣzaf
+
+[setting.third-party-plugin.button-check-for-updates]
+original=Check for updates
+translation=Senqed imuccḍen
+
+[setting.third-party-plugin.button-update-all-plugins]
+original=Update all
+translation=Mucceḍ akk
+
+[setting.third-party-plugin.label-current-plugins]
+original=Current plugins
+translation=Isiɣzaf imiranen
+
+[setting.third-party-plugin.msg-checking-for-updates]
+original=Checking for updates...
+translation=Asenqed n yimuccḍen...
+
+[setting.third-party-plugin.label-currently-installed]
+original=You currently have {{count}} plugin installed.
+translation=Tesɛiḍ tura {{count}} n usiɣzef yettwasbedden.
+
+[setting.third-party-plugin.label-currently-installed_plural]
+original=You currently have {{count}} plugins installed.
+translation=Tesɛiḍ tura {{count}} n yisiɣzaf yettwasbedden.
+
+[setting.third-party-plugin.msg-no-updates-found]
+original=No plugin updates found.
+translation=Ulac imuccḍen n yisiɣzaf i yettwafan.
+
+[setting.third-party-plugin.msg-updates-found]
+original=Found {{count}} plugin to update.
+translation=Yettwafa {{count}} n usiɣzef i umucceḍ.
+
+[setting.third-party-plugin.msg-updates-found_plural]
+original=Found {{count}} plugins to update.
+translation=Ttwafan {{count}} n yisiɣzaf i umucceḍ.
+
+[setting.third-party-plugin.msg-update-plugin]
+original=Update to version {{version}}
+translation=Mucceḍ ɣer lqem {{version}}
+
+[setting.third-party-plugin.option-search-installed-plugin]
+original=Search installed plugins
+translation=Nadi isiɣzaf yettwasbedden
+
+[setting.third-party-plugin.option-search-installed-plugin-description]
+original=Filter installed plugins by name or description.
+translation=Sti isiɣzaf yettwasbedden s yisem neɣ s weglam.
+
+[setting.third-party-plugin.placeholder-search-installed-plugin]
+original=Search installed plugins...
+translation=Nadi isiɣzaf yettwasbedden...
+
+[setting.third-party-plugin.show-installed-only]
+original=Show installed only
+translation=Sken kan wid yettwasbedden
+
+[setting.third-party-plugin.label-donate-modal-title]
+original=Donate to support {{name}}
+translation=Mudd tawsa i tallelt n {{name}}
+
+[setting.third-party-plugin.label-donate-modal-text1]
+original=Plugin developers are community volunteers who make amazing things out of passion. If you find this plugin useful, please consider funding its development.
+translation=Ineflayen n yisiɣzaf d iwiziwen n umɣiwan i ixeddmen tiɣawsiwin igerrzen s tayri. Ma yella twalaḍ asiɣzef-a isɛa tanfa, ttxil-k·m xemmem ad tefkeḍ afus n tallalt i usnefli-ines.
+
+[setting.third-party-plugin.label-donate-modal-text2]
+original=100% of your contribution will go to the plugin developer; Obsidian does not take a cut. The funding platform they choose might charge a fee.
+translation=100% n tedrimen-ik·im ad ṛuḥent ɣer uneflay n usiɣzef; Obsidian ur ittekkes ara aḥric-is. Tiɣeṛɣeṛt n tallalt n tedrimen i d-fernen tezmer ad tekkes kran seg tedrimt-a.
+
+[setting.third-party-plugin.label-donate-modal-text3]
+original=Thanks for your generous support!
+translation=Tanemmirt ɣef tallalt-ik·im igerrzen!
+
+[setting.third-party-plugin.label-support-this-plugin]
+original=Support this plugin:
+translation=Mudd tallelt i usiɣzef-a:
+
+[setting.third-party-plugin.label-search-summary]
+original=Showing {{pluginCount}}
+translation=Yeskanay-d {{pluginCount}}
+
+[setting.third-party-plugin.label-by-popularity]
+original=Most downloaded
+translation=Wid yettwasidren aṭas
+
+[setting.third-party-plugin.label-by-released]
+original=Recently released
+translation=Yeffeɣ-d melmi kan
+
+[setting.third-party-plugin.label-by-updated]
+original=Recently updated
+translation=Yettwamucceḍ melmi kan
+
+[setting.third-party-plugin.label-alphabetical]
+original=Alphabetical
+translation=S wagemmay
+
+[setting.third-party-plugin.label-last-updated]
+original=Updated {{time}}
+translation=Yettwamucceḍ {{time}}
+
+[setting.mobile-toolbar.name]
+original=Toolbar
+translation=Tafeggagt n yifecka
+
+[setting.mobile-toolbar.option-configure-quick-action]
+original=Configure mobile Quick Action
+translation=Swel tigawt taruradt n tiliɣri
+
+[setting.mobile-toolbar.option-configure-quick-action-description]
+original=Configure which command to trigger when pulling down from the top. The current command is set to “{{command}}”.
+translation=Swel anta taladna ara tenḍeḥḍ mi ara d-tjebdeḍ seg ufella. Taladna tamirant tettwasbedd ɣef “{{command}}”.
+
+[setting.mobile-toolbar.msg-missing-quick-action]
+original=Action not configured
+translation=Tigawt ur tettwaswel ara
+
+[setting.mobile-toolbar.button-configure]
+original=Configure
+translation=Swel
+
+[setting.mobile-toolbar.placeholder-select-quick-action]
+original=Select Quick Action...
+translation=Fren Tigawt Taruradt...
+
+[setting.mobile-toolbar.quick-action-disabled]
+original=None
+translation=Ulac
+
+[setting.mobile-toolbar.manage-toolbar-options]
+original=Manage toolbar options
+translation=Sefrek tixtiṛiyin n tfeggagt n yifecka
+
+[setting.mobile-toolbar.option-internal-link]
+original=Add internal link
+translation=Rnu aseɣwen agensan
+
+[setting.mobile-toolbar.option-internal-embed]
+original=Add embed
+translation=Rnu aseddu
+
+[setting.mobile-toolbar.option-tag]
+original=Add tag
+translation=Rnu ticṛeṭ
+
+[setting.mobile-toolbar.option-heading]
+original=Toggle heading
+translation=Senfel tasenṭit
+
+[setting.mobile-toolbar.option-strikethrough]
+original=Toggle strikethrough
+translation=Senfel ajeṛṛeḍ ɣef weḍris
+
+[setting.mobile-toolbar.option-highlight]
+original=Toggle highlight
+translation=Qluqel asebrureq
+
+[setting.mobile-toolbar.option-code]
+original=Toggle code
+translation=Qluqel tangalt
+
+[setting.mobile-toolbar.option-blockquote]
+original=Toggle blockquote
+translation=Qluqel iḥder n ubedder
+
+[setting.mobile-toolbar.option-inline-math]
+original=Toggle inline math
+translation=Qluqel tusnakt deg yizirig
+
+[setting.mobile-toolbar.option-math-block]
+original=Toggle math block
+translation=Qluqel iḥder n tusnakt
+
+[setting.mobile-toolbar.option-markdown-link]
+original=Add Markdown link
+translation=Rnu aseɣwen Markdown
+
+[setting.mobile-toolbar.option-bullet-list]
+original=Toggle bullet list
+translation=Qluqel tabdart s tlilac
+
+[setting.mobile-toolbar.option-numbered-list]
+original=Toggle numbered list
+translation=Qluqel tabdart s wuṭṭunen
+
+[setting.mobile-toolbar.option-indent-list]
+original=Indent list item
+translation=Siẓ aferdis n tebdart
+
+[setting.mobile-toolbar.option-unindent-list]
+original=Unindent list item
+translation=Kkes asiẓi n uferdis n tebdart
+
+[setting.mobile-toolbar.option-undo]
+original=Undo
+translation=Semmet
+
+[setting.mobile-toolbar.option-redo]
+original=Redo
+translation=Ales
+
+[setting.mobile-toolbar.option-move-caret-up]
+original=Move caret up
+translation=Sali taḥnaccaṭ
+
+[setting.mobile-toolbar.option-move-caret-down]
+original=Move caret down
+translation=Sider taḥnaccaṭ
+
+[setting.mobile-toolbar.option-move-caret-left]
+original=Move caret left
+translation=Smutti taḥnaccaṭ ɣer zelmeḍ
+
+[setting.mobile-toolbar.option-move-caret-right]
+original=Move caret right
+translation=Smutti taḥnaccaṭ ɣer yeffus
+
+[setting.mobile-toolbar.option-first-line]
+original=Go to first line
+translation=Ddu ɣer yizirig amezwaru
+
+[setting.mobile-toolbar.option-last-line]
+original=Go to last line
+translation=Ddu ɣer yizirig aneggaru
+
+[setting.mobile-toolbar.option-toggle-keyboard]
+original=Toggle keyboard
+translation=Qluqel anasiw
+
+[setting.mobile-toolbar.option-configure-toolbar]
+original=Configure mobile toolbar
+translation=Swel tafeggagt n yifecka n tiliɣri
+
+[setting.mobile-toolbar.option-added-options]
+original=Added options
+translation=Tixtiṛiyin yettwarnan
+
+[setting.mobile-toolbar.option-more-toolbar-options]
+original=More toolbar options
+translation=Ugar n tixtiṛiyin n tfeggagt n yifecka
+
+[setting.mobile-toolbar.option-attach]
+original=Insert attachment
+translation=Ger amedday
+
+[editor.search.placeholder-find]
+original=Find...
+translation=Af-d...
+
+[editor.search.placeholder-replace]
+original=Replace...
+translation=Semselsi...
+
+[editor.search.label-exit-search]
+original=Exit search
+translation=Ffeɣ seg unadi
+
+[editor.search.label-next]
+original=Next
+translation=Uḍfir
+
+[editor.search.label-previous]
+original=Previous
+translation=Uzwir
+
+[editor.search.label-find-all]
+original=Find all
+translation=Af-d akk
+
+[editor.search.label-replace]
+original=Replace
+translation=Semselsi
+
+[editor.search.label-replace-all]
+original=Replace all
+translation=Semselsi akk
+
+[editor.link-suggestion.label-type-hash]
+original=Type #
+translation=Aru #
+
+[editor.link-suggestion.label-link-heading]
+original=to link heading
+translation=i useɣwen n tsenṭit
+
+[editor.link-suggestion.label-type-block]
+original=Type ^
+translation=Aru ^
+
+[editor.link-suggestion.label-link-block]
+original=to link blocks
+translation=i useɣwen n yiḥedran
+
+[editor.link-suggestion.label-type-pipe]
+original=Type |
+translation=Aru |
+
+[editor.link-suggestion.label-change-display-text]
+original=to change display text
+translation=i ubeddel n weḍris n uskan
+
+[editor.link-suggestion.label-no-alias]
+original=Display text
+translation=Aḍris n uskan
+
+[editor.link-suggestion.label-no-heading]
+original=Heading
+translation=Tasenṭit
+
+[editor.link-suggestion.label-no-match-found]
+original=No match found
+translation=Ulac amṣada i yettwafan
+
+[editor.link-suggestion.label-image-size]
+original=Image size: {{size}}px wide
+translation=Tiddi n tugna: {{size}}px di tehri
+
+[editor.link-suggestion.label-accept]
+original=to accept
+translation=i weqbal
+
+[editor.link-suggestion.label-new-footnote]
+original=New footnote...
+translation=Awennit amaynut n uḍar usebter...
+
+[editor.spellcheck.no-suggestion]
+original=No suggestions...
+translation=Ulac isumar...
+
+[editor.spellcheck.add-to-dictionary]
+original=Add to dictionary
+translation=Rnu ɣer umawal
+
+[editor.menu.edit-link]
+original=Edit link
+translation=Ẓreg aseɣwen
+
+[editor.menu.edit-tag]
+original=Edit tag
+translation=Ẓreg ticṛeṭ
+
+[editor.menu.label-edit-block]
+original=Edit this block
+translation=Ẓreg iḥder-a
+
+[editor.menu.label-delete-footref-and-note]
+original=Delete footnote and reference
+translation=Kkes awennit n uḍar ysebter d temselɣut
+
+[editor.menu.reset-size]
+original=Reset size
+translation=Wennez tiddi
+
+[editor.menu.delete-image]
+original=Delete image
+translation=Kkes tugna
+
+[editor.heading-suggestion.label-no-heading]
+original=No heading
+translation=Ulac tasenṭit
+
+[editor.heading-suggestion.label-heading-level]
+original=Heading {{level}}
+translation=Tasenṭit {{level}}
+
+[editor.print-modal.title]
+original=Export to PDF
+translation=Sifeḍ ɣer PDF
+
+[editor.print-modal.caption]
+original=Export “{{filename}}” to PDF with the settings below.
+translation=Sifeḍ “{{filename}}” ɣer PDF s yiɣewwaren yellan ddaw-a.
+
+[editor.print-modal.setting-page-size]
+original=Page size
+translation=Tiddi n usebter
+
+[editor.print-modal.setting-include-file-name]
+original=Include file name as title
+translation=Seddu isem n ufaylu d azwel
+
+[editor.print-modal.setting-landscape]
+original=Landscape
+translation=Agama
+
+[editor.print-modal.setting-margin]
+original=Margin
+translation=Tama
+
+[editor.print-modal.setting-margin-default]
+original=Default
+translation=S umezwer
+
+[editor.print-modal.setting-margin-minimal]
+original=Minimal
+translation=Adday
+
+[editor.print-modal.setting-margin-none]
+original=None
+translation=Ulac
+
+[editor.print-modal.setting-downscale-percent]
+original=Downscale percent
+translation=Afmiḍi n wefnaẓ
+
+[editor.print-modal.button-export-to-pdf]
+original=Export to PDF
+translation=Sifeḍ ɣer PDF
+
+[editor.link-popover.tooltip-follow-link]
+original=Follow link
+translation=Ḍfaṛ aseɣwen
+
+[editor.link-popover.tooltip-open-link]
+original=Open link
+translation=Ldi aseɣwen
+
+[editor.link-popover.tooltip-search-tag]
+original=Search tag
+translation=Nadi ticṛeṭ
+
+[interface.embed-cannot-find]
+original=Cannot find:
+translation=Ur yezmir ara ad yaf:
+
+[interface.label-unable-to-find-section]
+original=Unable to find “{{subpath}}” in {{file}}
+translation=D awezɣi tifin n “{{subpath}}” deg {{file}}
+
+[interface.embed-open-in-default-app-tooltip]
+original=Open in default app
+translation=Ldi deg usnas amezwer
+
+[interface.empty-sidebar]
+original=The sidebar is empty, try dragging a tab here.
+translation=Tafeggagt tidisant d tilemt, ɛreḍ ad d-tzuɣṛeḍ iccer ɣer dagi.
+
+[interface.sidebar-expand]
+original=Expand
+translation=Derrec
+
+[interface.sidebar-collapse]
+original=Collapse
+translation=Fneẓ
+
+[interface.msg-fail-to-save-file]
+original=Failed to save file “{{filepath}}”. {{message}}. Make a backup of the contents of this file now to avoid losing data.
+translation=Yecceḍ weḥraz n ufaylu “{{filepath}}”. {{message}}. Xdem aḥraz i ugbur n ufaylu-a tura i wakken ur tesṛuḥuyeḍ ara isefka.
+
+[interface.msg-failed-to-load-plugin]
+original=Failed to load plugin “{{plugin}}”
+translation=Yecceḍ usali n usiɣzef “{{plugin}}”
+
+[interface.msg-plugin-error]
+original=Plugin “{{plugin}}” encountered an error while loading
+translation=Asiɣzef “{{plugin}}” yemlal-d tuccḍa deg usali
+
+[interface.msg-failed-to-load-file]
+original=Failed to open “{{filepath}}”
+translation=Yecceḍ ulday n “{{filepath}}”
+
+[interface.msg-failed-to-open-href]
+original=Cannot open location “{{href}}”
+translation=D awezɣi ulday n wemkan “{{href}}”
+
+[interface.no-file]
+original=No file
+translation=Ulac afaylu
+
+[interface.msg-file-changed]
+original=“{{file}}” has been modified externally, merging changes automatically.
+translation=“{{file}}” yettwabeddel s wudem uffiɣ, azday n yibeddilen s wudem awurman.
+
+[interface.manage-vaults]
+original=Manage vaults...
+translation=Sefrek ikaramen n weḥraz...
+
+[interface.help]
+original=Help
+translation=Tallalt 
+
+[interface.settings]
+original=Settings
+translation=Iɣewwaṛen
+
+[interface.drag-to-rearrange]
+original=Drag to rearrange
+translation=Zuɣeṛ akken ad talseḍ aseggem 
+
+[interface.msg-switched-to-read]
+original=Switched default view mode to reading view.
+translation=Askar n uskan umezwer yettwasenfel ɣer taskant n tɣuri.
+
+[interface.msg-switched-to-edit]
+original=Switched default view mode to editing view.
+translation=Askar n uskan n umezwer yettwasenfel ɣer taskant n teẓrigt.
+
+[interface.msg-upgrade-installer]
+original=To use this feature, please re-install with latest installer available from our website.
+translation=I useqdec n tmahilt-agi, ttxil-k·m ales asbeddi s umsebded aneggaru i yestufan deg usmel-nneɣ Web.
+
+[interface.msg-slow-boot]
+original=Slow startup time detected.
+translation=Akud n usekker aẓayan yettwaf.
+
+[interface.msg-desktop-only-feature]
+original=This feature is only available in the desktop app.
+translation=Tamahilt-a tella kan deg usnas n tnarit.
+
+[interface.tooltip-restore-default-settings]
+original=Restore default settings
+translation=Err-d iɣewwaren imezwar
+
+[interface.label-copy]
+original=Copy to clipboard
+translation=Nɣel ɣer tecfawit
+
+[interface.label-copy-short]
+original=Copy
+translation=Nɣel
+
+[interface.copied_generic]
+original=Copied to your clipboard
+translation=Yettwanɣel ɣer tecfawit-ik·im
+
+[interface.copied]
+original={{item}} copied to your clipboard
+translation={{item}} yettwanɣel ɣer tecfawit-inek·inem
+
+[interface.copy_failed]
+original=Unable to copy to your clipboard
+translation=D awezɣi anɣal ɣer tecfawit-inek·inem
+
+[interface.prompt-filter]
+original=Filter...
+translation=Tastayt... 
+
+[interface.msg-codeblock-render-error]
+original=Encountered an error while rendering code block.
+translation=Tella-d tuccḍa deg ubeggeḍ n yiḥder n tengalt.
+
+[interface.msg-open-file-through-uri]
+original=Opened file “{{path}}”
+translation=Yeldi ufaylu “{{path}}”
+
+[interface.msg-file-not-found-through-uri]
+original=File “{{name}}” not found.
+translation=Afaylu “{{name}}” ur yettwafa ara.
+
+[interface.msg-invalid-uri-action]
+original=Unrecognized URI action: {{action}}
+translation=Tigawt URI ur tettwaɛqel ara: {{action}}
+
+[interface.delete-action-short-name]
+original=Delete
+translation=Kkes 
+
+[interface.msg-indexing]
+original=Indexing vault...
+translation=Asmiter n ukaram n weḥraz...
+
+[interface.msg-indexing-desc]
+original=Some functionality may not be available until this is complete.
+translation=Kra n tmahilin zemrent ur stufant ara alamma yekfa waya.
+
+[interface.msg-indexing-complete]
+original=Indexing complete.
+translation=Asmiter yekfa.
+
+[interface.msg-sandbox-vault]
+original=This is a sandbox vault.\nChanges you make in this vault will be lost.
+translation=Wagi d akaram n weḥraz n tenkult n yijdi.\nIbeddilen ara texdmeḍ deg ukaram-a ad ṛuḥen.
+
+[interface.msg-indexed-db-not-supported]
+original=IndexedDB is required for this feature, but it is currently disabled.
+translation=IndexedDB yettwasra i tamahilt-agi, maca yettwasnes akka tura.
+
+[interface.msg-indexed-db-i-o-s]
+original=If you are using iOS in Lockdown Mode, please exclude Obsidian from the "Configure Web Browsing" setting of Lockdown Mode.
+translation=Ma yella tseqdaceḍ iOS s waskar n usekkweṛ, ttxil-k·m kkes Obsidian seg iɣewwaṛen "Tawila n tunigin ɣef Web" n waskar n usekkweṛ.
+
+[interface.label-enter-to-create]
+original=Enter to create
+translation=Sekcem iwakken ad d-tesnulfuḍ
+
+[interface.label-update-available]
+original=Update Available
+translation=Lqem yewjed
+
+[interface.label-debug-info]
+original=Debug info
+translation=Talɣut useɣti 
+
+[interface.button-learn-more]
+original=Learn more
+translation=Lmed ugar
+
+[interface.button-not-now]
+original=Not now
+translation=Mačči tura
+
+[interface.button-add]
+original=Add
+translation=Rnu
+
+[interface.button-manage]
+original=Manage
+translation=Sefrek 
+
+[interface.label-new-tab]
+original=New tab
+translation=Iccer amaynut
+
+[interface.option-hide-]
+original=Hide ribbon
+translation=Ffer tasfift
+
+[interface.msg-tab-busy]
+original=This tab is currently busy, please try again later
+translation=Iccer-a yecɣel tura, ɛreḍ tikkelt nniḍen ticki
+
+[interface.formatting.label-formatting]
+original=Format
+translation=Amasal
+
+[interface.formatting.label-paragraph]
+original=Paragraph
+translation=Taseddaṛt
+
+[interface.formatting.label-insert]
+original=Insert
+translation=Ger
+
+[interface.formatting.insert-link]
+original=Add link
+translation=Rnu aseɣwen
+
+[interface.formatting.insert-external-link]
+original=Add external link
+translation=Rnu aseɣwen uffiɣ
+
+[interface.formatting.insert-callout]
+original=Callout
+translation=Tiɣṛi
+
+[interface.formatting.insert-horizontal-rule]
+original=Horizontal rule
+translation=Izirig aglawan
+
+[interface.formatting.insert-code-block]
+original=Code block
+translation=Iḥder n tengalt
+
+[interface.formatting.insert-math-block]
+original=Math block
+translation=Iḥder n tusnakt
+
+[interface.formatting.insert-table]
+original=Table
+translation=Tafelwit
+
+[interface.formatting.insert-footnote]
+original=Footnote
+translation=Awennit n uḍar usebter
+
+[interface.formatting.toggle-bold]
+original=Bold
+translation=Azuran
+
+[interface.formatting.toggle-code]
+original=Code
+translation=Tangalt
+
+[interface.formatting.toggle-comments]
+original=Comment
+translation=Awennit
+
+[interface.formatting.toggle-highlight]
+original=Highlight
+translation=Sebrureq
+
+[interface.formatting.toggle-italics]
+original=Italic
+translation=Uknan
+
+[interface.formatting.toggle-strikethrough]
+original=Strikethrough
+translation=Yettwajerreḍ
+
+[interface.formatting.toggle-math]
+original=Math
+translation=Tusnakt
+
+[interface.formatting.toggle-bullet-list]
+original=Bullet list
+translation=Tabdart s tlilac
+
+[interface.formatting.toggle-checklist]
+original=Task list
+translation=Tabdart n tiwuriwin
+
+[interface.formatting.toggle-numbered-list]
+original=Numbered list
+translation=Tabdart s wuṭṭunen
+
+[interface.formatting.set-heading]
+original=Heading {{level}}
+translation=Tasenṭit {{level}}
+
+[interface.formatting.no-heading]
+original=Body
+translation=Tafekka
+
+[interface.formatting.clear]
+original=Clear formatting
+translation=Sfeḍ amasal
+
+[interface.formatting.toggle-quote]
+original=Quote
+translation=Abdar
+
+[interface.empty-state.empty]
+original=Empty
+translation=Ilem
+
+[interface.empty-state.no-file-open]
+original=No file is open
+translation=Ulac afaylu yeldin
+
+[interface.empty-state.create-new-file]
+original=Create new note
+translation=Snulfu-d tazmilt tamaynut
+
+[interface.empty-state.go-to-file]
+original=Go to file
+translation=Ddu ɣer ufaylu
+
+[interface.empty-state.see-recent-files]
+original=See recent files
+translation=Wali ifuyla ineggura
+
+[interface.empty-state.close]
+original=Close
+translation=Mdel
+
+[interface.empty-state.close-all]
+original=Close all “{{id}}” tabs ({{count}})
+translation=Mdel akk iccaren “{{id}}” ({{count}})
+
+[interface.empty-state.unknown-pane-title]
+original=Plugin no longer active
+translation=Asiɣzef dayen ur yermid ara
+
+[interface.empty-state.unknown-pane-desc]
+original=The plugin that created this tab ({{type}}) has gone away.
+translation=Asiɣzef i d-yesnulfan iccer-a ({{type}}) iruḥ.
+
+[interface.release-notes.tab-title]
+original=Release Notes {{version}}
+translation=Iwenniten n lqem {{version}}
+
+[interface.release-notes.msg-missing-release-notes]
+original=No release notes available for {{version}}.
+translation=Ulac iwenniten n lqem yellan i {{version}}.
+
+[interface.release-notes.msg-failed-to-load]
+original=Could not load release notes for {{version}}.
+translation=Ur yezmir ara ad isali iwenniten n lqem n {{version}}.
+
+[interface.release-notes.msg-release-date]
+original=Released on {{date}}
+translation=Yeffeɣ-d deg {{date}}
+
+[interface.release-notes.label-release]
+original=What's new in {{version}}
+translation=D acu i d amaynut deg lqem {{version}}
+
+[interface.menu.edit-view]
+original=Current view: editing
+translation=Askan amiran: taẓrigt
+
+[interface.menu.read-view]
+original=Current view: reading
+translation=Askan amiran: taɣuri
+
+[interface.menu.ribbon]
+original=Ribbon
+translation=Tasefift
+
+[interface.menu.left-sidebar]
+original=Left sidebar
+translation=Agalis n tama tazelmaṭ
+
+[interface.menu.right-sidebar]
+original=Right sidebar
+translation=Agalis n tama tayeffust
+
+[interface.menu.switch-to-edit-view]
+original=Click to edit
+translation=Sit iwakken ad tẓergeḍ
+
+[interface.menu.switch-to-read-view]
+original=Click to read
+translation=Sit iwakken ad teɣreḍ
+
+[interface.menu.mod-click-open-new-tab]
+original={{key}}+Click to open to the right
+translation={{key}}+Sit iwakken ad teldiḍ ɣer yeffus
+
+[interface.menu.msg-markdown-copy-instructions]
+original=Press {{key}}+C to copy source
+translation=Tekki ɣef {{key}}+C iwakken ad tenɣeleḍ aɣbalu
+
+[interface.menu.find]
+original=Find...
+translation=Nadi...
+
+[interface.menu.replace]
+original=Replace...
+translation=Semselsi...
+
+[interface.menu.edit]
+original=Edit
+translation=Ẓreg
+
+[interface.menu.remove]
+original=Remove
+translation=Kkes
+
+[interface.menu.remove-from-list]
+original=Remove from list
+translation=Kkes seg tebdart
+
+[interface.menu.rename]
+original=Rename
+translation=Snifel isem
+
+[interface.menu.preview]
+original=Preview
+translation=Azarskan
+
+[interface.menu.more-options]
+original=More options
+translation=Tixtiṛiyin nniḍen
+
+[interface.menu.close]
+original=Close
+translation=Mdel
+
+[interface.menu.close-all]
+original=Close all
+translation=Mdel akk
+
+[interface.menu.close-tabs-with-count]
+original=Close {{count}} tab
+translation=Mdel {{count}} yiccer
+
+[interface.menu.close-tabs-with-count_plural]
+original=Close {{count}} tabs
+translation=Mdel {{count}} yiccaren
+
+[interface.menu.close-others]
+original=Close others
+translation=Mdel wiyiḍ
+
+[interface.menu.close-after]
+original=Close tabs after
+translation=Mdel iccaren deffir
+
+[interface.menu.pin]
+original=Pin
+translation=Sbeḍ
+
+[interface.menu.unpin]
+original=Unpin
+translation=Kkes asbeḍ
+
+[interface.menu.unlink-tab]
+original=Unlink tab
+translation=Kkes aseɣwen n yiccer
+
+[interface.menu.link-tab]
+original=Link with tab...
+translation=Qqen d yiccer...
+
+[interface.menu.toggle-source-mode]
+original=Source mode
+translation=Askar n weɣbalu
+
+[interface.menu.toggle-reading-view]
+original=Reading view
+translation=Askan n tɣuri
+
+[interface.menu.add-property]
+original=Add file property
+translation=Rnu arat n ufaylu
+
+[interface.menu.delete-file]
+original=Delete file
+translation=Kkes afaylu
+
+[interface.menu.create-file]
+original=Create this file
+translation=Snulfu-d afaylu-a
+
+[interface.menu.open-link]
+original=Open link
+translation=Ldi aseɣwen
+
+[interface.menu.open-in-new-tab]
+original=Open in new tab
+translation=Ldi deg yiccer amaynut
+
+[interface.menu.open-to-the-right]
+original=Open to the right
+translation=Ldi ɣer yeffus
+
+[interface.menu.copy-url]
+original=Copy URL
+translation=Nɣel URL
+
+[interface.menu.copy]
+original=Copy
+translation=Nɣel
+
+[interface.menu.cut]
+original=Cut
+translation=Gzem
+
+[interface.menu.paste]
+original=Paste
+translation=Senteḍ
+
+[interface.menu.copy-path]
+original=Copy path
+translation=Nɣel abrid
+
+[interface.menu.copy-image]
+original=Copy image
+translation=Nɣel tugna
+
+[interface.menu.copy-obsidian-url]
+original=as Obsidian URL
+translation=am URL n Obsidian
+
+[interface.menu.copy-full-path]
+original=from system root
+translation=seg waẓaṛ n unagraw
+
+[interface.menu.copy-vault-path]
+original=from vault folder
+translation=seg ukaram n weḥraz
+
+[interface.menu.paste-as-plain-text]
+original=Paste as plain text
+translation=Senteḍ am weḍris aḥerfi
+
+[interface.menu.lookup-selection]
+original=Look up “{{selection}}”
+translation=Nadi “{{selection}}”
+
+[interface.menu.select-all]
+original=Select all
+translation=Fren akk
+
+[interface.menu.rename-heading]
+original=Rename this heading...
+translation=Snifel isem n tsenṭit-a...
+
+[interface.menu.rename-blockid]
+original=Rename this block ID...
+translation=Snifel isem n usulay n yiḥder-a...
+
+[interface.menu.open-in-new-window]
+original=Open in new window
+translation=Ldi deg usfaylu amaynut
+
+[interface.menu.move-to-new-window]
+original=Move to new window
+translation=Smutti ɣer usfaylu amaynut
+
+[interface.menu.open-in-browser]
+original=Open external link
+translation=Ldi aseɣwen uffiɣ
+
+[interface.menu.stack-tabs]
+original=Stack tabs
+translation=Semnenni iccaren
+
+[interface.menu.unstack-tabs]
+original=Unstack tabs
+translation=Kkes asemnenni n yiccaren
+
+[interface.menu.open-linked-view]
+original=Open linked view
+translation=Ldi askan yeqqnen
+
+[interface.tooltip.click-to-expand]
+original=Click to expand
+translation=Sit iwakken ad tsimɣureḍ
+
+[interface.tooltip.click-to-collapse]
+original=Click to collapse
+translation=Sit iwakken ad fenẓeḍ
+
+[interface.tooltip.alias]
+original=Alias
+translation=Tazaẓlut
+
+[interface.tooltip.not-created-yet]
+original=Not created yet, select to create
+translation=Ur d-yennulfa ara yakan, fren iwakken ad t-id-tesnulfuḍ
+
+[interface.start-screen.label-version]
+original=Version
+translation=Lqem
+
+[interface.start-screen.label-create-local-vault]
+original=Create local vault
+translation=Snulfu-d akaram n weḥraz adigan
+
+[interface.start-screen.option-open-folder-as-vault]
+original=Open folder as vault
+translation=Ldi akaram am ukaram n weḥraz n Obsidian
+
+[interface.start-screen.option-open-folder-as-vault-description]
+original=Choose an existing folder of Markdown files.
+translation=Fren akaram yellan n ifuyla Markdown.
+
+[interface.start-screen.option-create-vault]
+original=Create new vault
+translation=Snulfu-d akaram n weḥraz amaynut
+
+[interface.start-screen.option-create-vault-description]
+original=Create a new Obsidian vault under a folder.
+translation=Snulfu-d akaram n weḥraz amaynut n Obsidian ddaw ukaram.
+
+[interface.start-screen.option-connect-obsidian-sync]
+original=Open vault from Obsidian Sync
+translation=Ldi akaram n weḥraz seg Obsidian Sync
+
+[interface.start-screen.option-connect-obsidian-sync-description]
+original=Set up a synced vault with existing remote vault.
+translation=Sbedd akaram n weḥraz yettwamtawan d ukaram n weḥraz anmeggag yellan.
+
+[interface.start-screen.option-new-vault-name]
+original=Vault name
+translation=Isem n ukaram n weḥraz
+
+[interface.start-screen.option-new-vault-name-description]
+original=Pick a name for your awesome vault.
+translation=Fren isem i ukaram-ik·im.
+
+[interface.start-screen.option-new-vault-location]
+original=Location
+translation=Ideg
+
+[interface.start-screen.option-new-vault-location-description]
+original=Pick a place to put your new vault.
+translation=Fren ideg anda ara yers ukaram-ik·im n weḥraz amaynut.
+
+[interface.start-screen.label-new-vault-location-preview]
+original=Your new vault will be placed in: 
+translation=Akaram-ik·im amaynut ad yers deg: 
+
+[interface.start-screen.option-reveal-vault-in-explorer]
+original=Reveal vault in system explorer
+translation=Sken akaram n weḥraz deg unaram n unagraw
+
+[interface.start-screen.option-reveal-vault-in-explorer-mac]
+original=Reveal vault in Finder
+translation=Sken akaram n weḥraz deg Finder
+
+[interface.start-screen.option-rename-vault]
+original=Rename vault...
+translation=Beddel isem i ukaram n weḥraz...
+
+[interface.start-screen.option-copy-vault-i-d]
+original=Copy vault ID
+translation=Nɣel asulay n ukaram n weḥraz
+
+[interface.start-screen.msg-error-rename-exists]
+original=There is already a vault with this name.
+translation=Yella yakan ukaram n weḥraz s yisem-a.
+
+[interface.start-screen.msg-error-nested]
+original=Cannot move vault into a subfolder of itself.
+translation=Ur tezmireḍ ara ad tsiwḍeḍ akaram n weḥraz ɣer ukaram anaddaw n ines.
+
+[interface.start-screen.msg-error-rename-open]
+original=Can't rename a currently open vault.
+translation=Ur tezmireḍ ara ad tbeddleḍ isem i ukaram n weḥraz yeldin akka tura.
+
+[interface.start-screen.msg-rename-failed]
+original=Failed to rename vault.
+translation=Tuccḍa deg ubeddel n yisem n ukaram n weḥraz.
+
+[interface.start-screen.msg-rename-success]
+original=Successfully renamed vault.
+translation=Asnifel n yisem n ukaram n weḥraz yedda akken iwata.
+
+[interface.start-screen.option-move-vault]
+original=Move vault...
+translation=Smutti akaram n weḥraz...
+
+[interface.start-screen.msg-move-select-dest]
+original=Select destination folder
+translation=Fren akaram aɣerwaḍ
+
+[interface.start-screen.msg-error-move-exists]
+original=There is already a vault at the destination.
+translation=Yella yakan ukaram n weḥraz deg uɣerwaḍ-a.
+
+[interface.start-screen.msg-error-move-open]
+original=Can't move a currently open vault.
+translation=Ur tezmireḍ ara ad tsiwḍeḍ akaram n weḥrez yeldin.
+
+[interface.start-screen.msg-move-failed]
+original=Failed to move vault.
+translation=Tuccḍa deg usiweḍ n ukaram.
+
+[interface.start-screen.msg-move-success]
+original=Successfully moved vault.
+translation=Akaram yettwasiweḍ akken iwata.
+
+[interface.start-screen.option-remove]
+original=Remove from list
+translation=Kkes seg tebdart
+
+[interface.start-screen.button-quick-start]
+original=Quick start
+translation=Asekker arurad
+
+[interface.start-screen.button-open]
+original=Open
+translation=Ldi
+
+[interface.start-screen.button-browse]
+original=Browse
+translation=Inig
+
+[interface.start-screen.button-connect]
+original=Connect
+translation=Qqen
+
+[interface.start-screen.button-create-vault]
+original=Create
+translation=Snulfu-d 
+
+[interface.start-screen.button-back]
+original=Back
+translation=Uɣal ɣer deffir
+
+[interface.start-screen.msg-empty-vault-name]
+original=Vault name cannot be empty.
+translation=Isem n ukaram n weḥraz ur yezmir ara ad yili d ilem.
+
+[interface.start-screen.msg-trailing-dot-vault-name]
+original=Vault name cannot end with a dot.
+translation=Isem n ukaram n weḥraz ur yezmir ara ad ifakk s tneqqiṭ. 
+
+[interface.start-screen.msg-invalid-folder]
+original=Please pick a valid folder.
+translation=Ttxil-k·m fren akaram ameɣtu. 
+
+[interface.start-screen.msg-failed-to-create-vault]
+original=Failed to create vault.
+translation=Tuccḍa deg usnulfu n ukaram n weḥraz. 
+
+[interface.start-screen.msg-failed-to-create-vault-at-location]
+original=Could not create vault at the given location. Please double check the location and permission.
+translation=Ur yezmir ara ad yesnulfu akaram n weḥraz deg yideg-a. Ttxil-k·m senqed ideg akked turagt. 
+
+[interface.start-screen.msg-error-failed-to-open-vault]
+original=Failed to open.
+translation=Tuccḍa deg ulday. 
+
+[interface.start-screen.msg-error-remove-current-open-vault]
+original=Can't remove a currently open vault.
+translation=Ur tezmireḍ ara ad tekksed akaram n weḥraz yeldin tura. 
+
+[interface.start-screen.option-get-help]
+original=Get Help
+translation=Awi-d tallalt 
+
+[interface.start-screen.option-user-email]
+original=Email
+translation=Imayl 
+
+[interface.start-screen.placeholder-your-email]
+original=Your email...
+translation=Imayl-ik·im... 
+
+[interface.start-screen.option-user-password]
+original=Password
+translation=Awal uffir 
+
+[interface.start-screen.placeholder-your-password]
+original=Your password...
+translation=Awal-ik·im uffir... 
+
+[interface.start-screen.button-sign-in]
+original=Sign in
+translation=Anekcum 
+
+[interface.start-screen.button-setup]
+original=Setup
+translation=Asbeddi 
+
+[interface.start-screen.option-connect-vault-desc]
+original=Create a synced vault on this device.
+translation=Snulfu-d akaram n weḥraz amtawan deg yibenk-a. 
+
+[interface.start-screen.tooltip-own-vault]
+original=This is a remote vault owned by you.
+translation=Wagi d akaram n weḥraz anmeggag n inek·inem. 
+
+[interface.start-screen.tooltip-shared-vault]
+original=This is a remote vault shared with you.
+translation=Wagi d akaram n weḥraz anmeggag yettwabḍa yid-k·m.
+
+[interface.start-screen.mobile.label-start-screen]
+original=Your thoughts are yours.
+translation=Imektiyen-ik·im d ayla-k·m. 
+
+[interface.start-screen.mobile.label-synced]
+original=synced
+translation=yettwamtawa 
+
+[interface.start-screen.mobile.label-not-synced]
+original=not synced
+translation=ur yettwamtawa ara 
+
+[interface.start-screen.mobile.label-none]
+original=None
+translation=Ulac 
+
+[interface.start-screen.mobile.label-recommended]
+original=Recommended
+translation=Yettuwelleh
+
+[interface.start-screen.mobile.label-start-screen-desc]
+original=Obsidian stores notes on your device, so you can access them quickly and privately, even offline.\nYour data is stored in a secure local folder called a **vault**.
+translation=Obsidian yeḥrez tizmilen-ik·im deg ibenk-ik·im, iwakken ad ten-tafeḍ s urured d tbaḍnit, ula s waskar waruqqin.\nIsefka-inek·inem ttwajmɛen deg ukaram adigan aɣelsan iwumi qqaren **akaram n weḥraz**. 
+
+[interface.start-screen.mobile.option-create]
+original=Create a vault
+translation=Rnu akaram n weḥraz
+
+[interface.start-screen.mobile.option-use-existing]
+original=Use my existing vault
+translation=Seqdec akaram-iw n weḥraz yellan
+
+[interface.start-screen.mobile.label-sync-intro]
+original=To access your notes on other devices you need to set up sync.
+translation=I wakken ad tekcmeḍ ɣer tezwamil-inek deg yibenkan nniḍen, issefk ad tesweleḍ amtawa.
+
+[interface.start-screen.mobile.label-sync-intro-desc]
+original=Because Obsidian stores your notes on your devices, you'll need to set up sync if you want to access your notes on another phone or computer.\nYou can set up sync now, or just start writing and set it up later.
+translation=Imi Obsidian iḥerrez tizwamil-inek ɣef yibenkan-inek, issefk fell-ak ad tesweleḍ amtawa ma tebɣiḍ ad tekcmeḍ ɣer tezwamil-inek deg tiliɣri nniḍen neɣ aselkim.\nTzemreḍ ad tesweleḍ amtawa tura, neɣ ebd kan tira tura ad tesweleḍ amtawa s sakin.
+
+[interface.start-screen.mobile.option-setup-sync]
+original=Set up sync
+translation=Swel amtawa
+
+[interface.start-screen.mobile.option-skip]
+original=Continue without sync
+translation=Kemmel war amtawa
+
+[interface.start-screen.mobile.option-skip-short]
+original=Skip
+translation=Zgel
+
+[interface.start-screen.mobile.label-vault-create]
+original=Configure your new vault.
+translation=Swel akaram-inek n weḥraz amaynut.
+
+[interface.start-screen.mobile.button-create]
+original=Create vault
+translation=Rnu akaram n weḥraz
+
+[interface.start-screen.mobile.label-sync-setup]
+original=Sync setup
+translation=Aswel n umtawa
+
+[interface.start-screen.mobile.label-sync-setup-desc]
+original=Create a synced vault on your Obsidian account so you can access your data from other devices.
+translation=Rnu akaram n weḥraz yettwamtawan deg umiḍan-ik·im Obsidian i wakken ad tekcmeḍ ɣer isefka-k·m seg yibenkan nniḍen.
+
+[interface.start-screen.mobile.label-remote-vault-create]
+original=Sync encryption
+translation=Awgelhen n umtawi
+
+[interface.start-screen.mobile.option-encryption-custom]
+original=End-to-end encryption
+translation=Awgelhen seg yixef ɣer yixef
+
+[interface.start-screen.mobile.option-encryption-custom-desc]
+original=Offers the strongest security but requires you to safely store your encryption password
+translation=Yettak-d taɣellist i yiǧehden ugar maca issefk fell-ak·am ad tḥerzeḍ awal n uɛeddi n uwgelhen-ik·im s tɣellist
+
+[interface.start-screen.mobile.option-encryption-managed]
+original=Standard encryption
+translation=Awgelhen amezwer
+
+[interface.start-screen.mobile.option-encryption-managed-desc]
+original=Uses a key managed by Obsidian to protect your data in transit and on our servers.
+translation=Yesseqdac tasarut yettusefrken sɣur Obsidian i wakken ad iḥrez isefka-k·m mi tt-ddun d wid yellan ɣef yiqeddacen-nneɣ.
+
+[interface.start-screen.mobile.label-sync-settings]
+original=Sync Settings
+translation=Iɣewwaṛen n umtawa
+
+[interface.start-screen.mobile.label-sync-settings-desc]
+original=Do you want to exclude any folders or files when syncing to this device?
+translation=Tebɣiḍ ad testixreḍ kra n ikaramen neɣ ifuyla mi ara txeddmeḍ amtawa ɣer ibenk-a?
+
+[interface.start-screen.mobile.button-start]
+original=Start syncing
+translation=Bdu amtawa
+
+[interface.start-screen.mobile.label-sign-in-or-sign-up]
+original=Create an Obsidian account or sign in
+translation=Rnu amiḍan Obsidian neɣ kcem
+
+[interface.start-screen.mobile.option-sign-up]
+original=Sign up
+translation=Jerred
+
+[interface.start-screen.mobile.option-sign-in]
+original=Sign in
+translation=Kcem
+
+[interface.start-screen.mobile.button-resend-email]
+original=Re-send email
+translation=Ales azen n yimayl
+
+[interface.start-screen.mobile.label-remote-vault-options]
+original=You have existing Sync vaults
+translation=Tesɛiḍ ikaramen n weḥraz yettwamtawan
+
+[interface.start-screen.mobile.label-remote-vault-options-desc]
+original=Do you want to create a new vault or connect to an existing synced vault?
+translation=Tebɣiḍ ad ternuḍ akaram n weḥraz amaynut neɣ ad teqqneḍ ɣer ukaram yettwamtawan yellan yakan?
+
+[interface.start-screen.mobile.option-remote-create]
+original=Create new Sync vault
+translation=Rnu akaram n weḥraz amaynut n umtawa
+
+[interface.start-screen.mobile.option-remote-choose]
+original=Choose an existing vault
+translation=Fren akaram n weḥraz yellan
+
+[interface.start-screen.mobile.button-logout]
+original=Log out
+translation=Ffeɣ
+
+[interface.start-screen.mobile.button-forgot-password]
+original=Forgot password
+translation=Awal n uɛeddi yettwattun
+
+[interface.start-screen.mobile.label-vault-name]
+original=Vault name
+translation=Isem n ukaram n weḥraz
+
+[interface.start-screen.mobile.label-vault-location]
+original=Vault location
+translation=Amkan n ukaram n weḥraz
+
+[interface.start-screen.mobile.label-device-storage]
+original=Device storage
+translation=Asekles n yibenk
+
+[interface.start-screen.mobile.label-device-storage-desc]
+original=Allows Obsidian data to be accessed by other apps.
+translation=Yettak isirigen i isefka n Obsidian ad ten-kcemen isnasen nniḍen.
+
+[interface.start-screen.mobile.label-requires-additional-permissions]
+original=Requires additional permissions.
+translation=Yesra isirigen nniḍen.
+
+[interface.start-screen.mobile.label-app-storage]
+original=App storage
+translation=Asekles n usnas
+
+[interface.start-screen.mobile.label-app-storage-desc1]
+original=Your data will not be accessible to other apps.
+translation=Isefka-k·m ur ttwakcamen ara i yisnasen nniḍen.
+
+[interface.start-screen.mobile.label-app-storage-desc2]
+original=Android will delete your data if you uninstall Obsidian.
+translation=Android ad yekkes isefka-k·m ma tekkseḍ Obsidian.
+
+[interface.start-screen.mobile.label-vault-location-desc]
+original=Your new vault will be placed in {{vaultLocation}}
+translation=Akaram-ik·im n weḥraz amaynut ad yettwasres deg {{vaultLocation}}
+
+[interface.start-screen.mobile.label-region-selection]
+original=Region
+translation=Tamnaḍt
+
+[interface.start-screen.mobile.label-region-selection-help]
+original=Choose a server region near you to make syncing faster.
+translation=Fren tamnaḍt n uqeddac i d-iqerben ɣuṛ-k·m i wakken ad yiwzil umtawa.
+
+[interface.start-screen.mobile.label-encryption-key]
+original=Encryption key
+translation=Tasarut n uwgelhen
+
+[interface.start-screen.mobile.label-encryption-key-help]
+original=This password cannot be changed later. If you forget your password, any remote data on Sync servers will be inaccessible forever.
+translation=Awal-a n uɛeddi ur yezmir ara ad yettwabeddel sakin. Ma tettuḍ awal-ik·im n uɛeddi, kra n yisefka inmeggagen deg iqeddacen n umtawa ad ilin ṛuḥen i lebda.
+
+[interface.start-screen.mobile.placeholder-vault-name]
+original=My vault
+translation=Akaram-iw n weḥraz
+
+[interface.start-screen.mobile.opt-region-selection-automatic]
+original=Automatic
+translation=Awurman
+
+[interface.start-screen.mobile.label-remote-vault-selection]
+original=Choose a vault
+translation=Fren akaram n weḥraz
+
+[interface.start-screen.mobile.label-remote-vault-selection-desc]
+original=Your account **{{email}}** has existing vaults you can connect to.
+translation=Amiḍan-ik·im **{{email}}** yesɛa ikaramen n weḥraz yellan i wumi tzemreḍ ad teqqneḍ.
+
+[interface.start-screen.mobile.label-sign-in]
+original=Sign in to your Obsidian account
+translation=Kcem ɣer umiḍan-ik·im Obsidian
+
+[interface.start-screen.mobile.label-forgot-password]
+original=Forgot password
+translation=Awal n uɛeddi yettwattun
+
+[interface.start-screen.mobile.button-reset-password]
+original=Reset password
+translation=Ales asbeddi n wawal n uɛeddi
+
+[interface.start-screen.mobile.msg-password-reset]
+original=We have sent an email to {{email}} to reset your password.
+translation=Nuzen-d imayl ɣer {{email}} i walsi n usbeddi n wawal-ik·im n uɛeddi.
+
+[interface.start-screen.mobile.label-sync-method-selection]
+original=Choose how to sync your notes
+translation=Fren amek ara tmataweḍ tizwamil-ik·im
+
+[interface.start-screen.mobile.label-sync-method-selection-desc]
+original=To use Obsidian on your devices you will need to sync your data.
+translation=I wakken ad tseqdceḍ Obsidian ɣef yibenkan-ik·im issefk ad tmataweḍ isefka-ik·im.
+
+[interface.start-screen.mobile.label-sync-pro1]
+original=Seamless across every device and OS.
+translation=S wudem war asaraf gar yal ibenk d unagraw n wekcam.
+
+[interface.start-screen.mobile.label-sync-pro2]
+original=Secured with the strongest end-to-end encryption standard.
+translation=Yettwaḥrez s wawal n uwgelhen s wudem tizeɣt iǧehden seg yixef ɣer yixef.
+
+[interface.start-screen.mobile.label-sync-pro3]
+original=Requires an Obsidian account.
+translation=Yesra amiḍan Obsidian.
+
+[interface.start-screen.mobile.label-icloud-con1]
+original=Only for iOS and macOS.
+translation=Ala kan i iOS d macOS.
+
+[interface.start-screen.mobile.label-icloud-con2]
+original=Not encrypted by default.
+translation=Ur yettwawgelhen ara s umezwer.
+
+[interface.start-screen.mobile.label-third-party-desc1]
+original=Requires third-party plugins or tools.
+translation=Yesra isiɣzaf neɣ ifecka n wis kraḍ.
+
+[interface.start-screen.mobile.label-third-party-desc2]
+original=May not be encrypted by default.
+translation=Yezmer ur yettwawgelhen ara s umezwer.
+
+[interface.start-screen.mobile.opt-use-obsidian-sync]
+original=Use Obsidian Sync
+translation=Seqdec Amtawa Obsidian
+
+[interface.start-screen.mobile.opt-use-icloud]
+original=Use iCloud
+translation=Seqdec iCloud
+
+[interface.start-screen.mobile.opt-use-other]
+original=Use third-party sync
+translation=Seqdec amtawa n wis kraḍ
+
+[interface.start-screen.mobile.opt-learn-other-sync]
+original=Other sync methods
+translation=Tarrayin nniḍen n umtawa
+
+[interface.start-screen.mobile.opt-use-supported]
+original=Use supported sync methods
+translation=Seqdec tarrayin n umtawa yettusefraken
+
+[interface.start-screen.mobile.label-sync-restore]
+original=Where is your vault located?
+translation=Anda yezga ukaram-ik·im n weḥraz?
+
+[interface.start-screen.mobile.label-other]
+original=Other
+translation=Nniḍen
+
+[interface.start-screen.mobile.label-other-sync]
+original=Third-party sync
+translation=Amtawa n wis kraḍ
+
+[interface.start-screen.mobile.label-local-folder]
+original=On this device
+translation=Ɣef yibenk-a
+
+[interface.start-screen.mobile.option-connect-icloud]
+original=Connect to iCloud
+translation=Qqen ɣer iCloud
+
+[interface.start-screen.mobile.option-connect-other]
+original=Connect to other sync service
+translation=Qqen ɣer umeẓlu n umtawa nniḍen
+
+[interface.start-screen.mobile.option-connect-sync]
+original=Connect to Obsidian Sync
+translation=Qqen ɣer Umtawa n Obsidian
+
+[interface.start-screen.mobile.option-connect-local-folder]
+original=Choose folder
+translation=Fren akaram
+
+[interface.start-screen.mobile.label-sync-other]
+original=Other syncing methods
+translation=Tarrayin nniḍen n umtawa
+
+[interface.start-screen.mobile.label-sync-other-desc]
+original=Obsidian officially supports two syncing methods: **Obsidian Sync** and **iCloud**.\nHowever, because Obsidian gives you control over your data there are other sync options you can use.\nThese options include third-party plugins and other tools which may require more advanced set up.\nTo use an alternate syncing method, **create a vault** and follow the instructions provided by the plugin or third-party sync provider.
+translation=Obsidian isefrak s wudem unṣib snat n tarrayin n umtawa: **Amtawa n Obsidian** d **iCloud**.\nMaca, imi Obsidian yettak-ak·am asenqed ɣef yisefka-k·m, llan tixtiṛiyin nniḍen n umtawa i tzemreḍ ad tseqdceḍ.\nTixtiṛiyin-a seddunt isiɣzaf n wis kraḍ d yifecka nniḍen i yezmren ad sran asbeddi aleqayan.\nI wakken ad tseqdceḍ tarrayt n umtawa nniḍen, **rnu akaram n weḥraz** yerna ḍfaṛ tinaḍin i d-yettunefken sɣur usiɣzef neɣ imefki n umtawa n wis kraḍ.
+
+[interface.start-screen.mobile.label-email-entry]
+original=Enter your email
+translation=Sekcem imayl-ik·im
+
+[interface.start-screen.mobile.label-email-entry-desc]
+original=Your email is required to create an Obsidian account.
+translation=Imayl-ik·im yettuseḥwaǧ i wakken ad ternuḍ amiḍan Obsidian.
+
+[interface.start-screen.mobile.label-signup]
+original=Enter your name and password
+translation=Sekcem isem-ik·im d wawal n uɛeddi
+
+[interface.start-screen.mobile.email-verification]
+original=Connect to Obsidian Sync
+translation=Qqen ɣer Umtawa n Obsidian
+
+[interface.start-screen.mobile.email-verification-desc]
+original=You should receive an email shortly to **{{email}}** with instructions to connect to Obsidian Sync.
+translation=Ad termesḍ imayl qrib ɣer **{{email}}** s tinaḍin i wakken ad teqqneḍ ɣer Umtawa n Obsidian.
+
+[interface.start-screen.mobile.icloud-missing-desc]
+original=Your iCloud vault was not detected. This could be due to any of the following reasons:
+translation=Akaram-ik·im n weḥraz iCloud ur yettwafa ara. Aya yezmer ad yili ɣef yiwet seg tmentilin-a:
+
+[interface.start-screen.mobile.icloud-missing-reason1]
+original=Your vault is on a different iCloud account than the one you are currently signed into on this device.
+translation=Akaram-ik·im n weḥraz yella ɣef umiḍan iCloud yemgaraden ɣef win s wayes tkecmeḍ tura deg yibenk-a.
+
+[interface.start-screen.mobile.icloud-missing-reason2]
+original=Your vault is not stored on the top-level Obsidian folder of your iCloud Drive.
+translation=Akaram-ik·im n weḥraz ur yettwaḥrez ara deg ukaram afellay Obsidian n iCloud Drive-ik·im.
+
+[interface.start-screen.mobile.i-cloud-unsupported]
+original=iCloud not supported
+translation=iCloud ur yettusefrak ara
+
+[interface.start-screen.mobile.i-cloud-unsupported-desc]
+original=iCloud syncing is only available on Apple devices. If your vault is currently syncing via iCloud, learn how to migrate your vault to a different sync service.
+translation=Amtawa n iCloud yestufa kan ɣef yibenkan n Apple. Ma yella akaram-ik·im n weḥraz yettmatawa tura s iCloud, lmed amek ara tinigeḍ akaram-ik·im n weḥraz ɣer umeẓlu n umtawa nniḍen.
+
+[interface.start-screen.mobile.allow-file-access]
+original=Allow file access
+translation=Sireg adduf ɣer ufaylu
+
+[interface.start-screen.mobile.msg-login-pending]
+original=Logging you in...
+translation=Anekcum tura...
+
+[interface.start-screen.mobile.msg-name-required]
+original=Vault name is required
+translation=Isem n ukaram n weḥraz yettuseḥwaǧ
+
+[interface.start-screen.mobile.msg-new-email-success]
+original=New confirmation email sent.
+translation=Imayl amaynut n usentem yettwazen.
+
+[interface.start-screen.mobile.msg-new-email-failure]
+original=Failed to resend email.
+translation=Yecceḍ alus n tuzna n yimayl.
+
+[interface.start-screen.mobile.msg-invalid-vault]
+original=Vault location must be a folder.
+translation=Amkan n ukaram n weḥraz ilaq ad yili d akaram.
+
+[interface.starter-content.welcome-filename]
+original=Welcome
+translation=Ansuf
+
+[interface.starter-content.welcome-file-content]
+original=This is your new *vault*.\n\nMake a note of something, [[create a link]], or try [the Importer](https://help.obsidian.md/Plugins/Importer)!\n\nWhen you're ready, delete this note and make the vault your own.
+translation=Wagi d *akaram-inek·inem n weḥraz* amaynut.\n\nXdem tazmilt ɣef kra, [[rnu aseɣwen]], neɣ ɛreḍ [Amaktar](https://help.obsidian.md/Plugins/Importer)!\n\nMi theggaḍ, kkes tazmilt-a yerna err akaram n weḥraz d ayla-k·m.
+
+[interface.drag-and-drop.insert-link-here]
+original=Insert link here
+translation=Ger aseɣwen dagi
+
+[interface.drag-and-drop.insert-links-here]
+original=Insert links here
+translation=Ger iseɣwan dagi
+
+[interface.drag-and-drop.move-into-folder]
+original=Move into “{{folder}}”
+translation=Smatti ɣer “{{folder}}”
+
+[interface.drag-and-drop.star-this-file]
+original=Star this file
+translation=Err itri i ufaylu-a
+
+[interface.drag-and-drop.star-these-files]
+original=Star these files
+translation=Err itri i yifuyla-a
+
+[interface.drag-and-drop.open-in-this-tab]
+original=Open in this tab
+translation=Ldi deg yiccer-a
+
+[interface.drag-and-drop.open-as-tab]
+original=Open as new tab
+translation=Ldi d iccer amaynut
+
+[interface.window.maximize]
+original=Maximize
+translation=Semɣer
+
+[interface.window.minimize]
+original=Minimize
+translation=Semẓi
+
+[interface.window.restore-down]
+original=Restore down
+translation=Err-d ɣer wadda
+
+[interface.window.close-window]
+original=Close window
+translation=Mdel asfaylu
+
+[interface.window.go-back]
+original=Go back
+translation=Uɣal ɣer deffir
+
+[interface.window.go-forward]
+original=Go forward
+translation=Ddu ɣer zdat
+
+[interface.start-up.loading-obsidian]
+original=Loading Obsidian...
+translation=Asali n Obsidian...
+
+[interface.start-up.obsidian-load-error]
+original=An error occurred while loading Obsidian.
+translation=Temlal-d tuccḍa deg usali n Obsidian.
+
+[interface.start-up.button-reload-app]
+original=Reload app
+translation=Ales asali n usnas
+
+[interface.start-up.button-reload-app-in-safe-mode]
+original=Reload app in Restricted Mode
+translation=Ales asali n usnas deg Uskar Ukrif
+
+[interface.start-up.button-open-another-vault]
+original=Open another vault
+translation=Ldi akaram n weḥraz nniḍen
+
+[interface.start-up.loading-plugins]
+original=Loading plugins...
+translation=Asali n yisiɣzaf...
+
+[interface.start-up.msg-plugin-hang]
+original=Plugin “{{plugin}}” is taking long to load. 
+translation=Asiɣzef “{{plugin}}” yeṭṭef aṭas n wakud i usali. 
+
+[interface.start-up.loading-vault]
+original=Loading vault...
+translation=Asali n ukaram n weḥraz...
+
+[interface.start-up.msg-failed-to-load-vault]
+original=Failed to load vault: 
+translation=Yecceḍ usali n ukaram n weḥraz: 
+
+[interface.start-up.loading-cache]
+original=Loading cache...
+translation=Asali n tzarkatut...
+
+[interface.start-up.loading-workspace]
+original=Loading workspace...
+translation=Asali n tallunt n umahil...
+
+[interface.mobile.action-import]
+original=Import into vault
+translation=Kter ɣer ukaram n weḥraz
+
+[interface.mobile.action-insert-text-desc]
+original=Add text to file:
+translation=Rnu aḍris ɣer ufaylu:
+
+[interface.mobile.action-choose-file-to-insert]
+original=Choose a file...
+translation=Fren afaylu...
+
+[interface.mobile.action-insert-text-into-file]
+original={{filename}}
+translation={{filename}}
+
+[interface.mobile.action-insert-link-into-file]
+original=Insert link into “{{filename}}”
+translation=Ger aseɣwen ɣer “{{filename}}”
+
+[interface.mobile.action-show-switcher]
+original=Show tab overview
+translation=Sken taskant tamatut n yicceran
+
+[interface.mobile.msg-importing]
+original=Importing...
+translation=Aktar...
+
+[interface.mobile.msg-import-success]
+original=Import success
+translation=Aktar yedda
+
+[interface.mobile.msg-failed-to-import-file]
+original=Failed to import file “{{filename}}”
+translation=Yecceḍ waktar n ufaylu “{{filename}}”
+
+[interface.mobile.msg-back-again-to-exit]
+original=Press back again to exit.
+translation=Sit ɣef deffir tikkelt nniḍen i wakken ad teffɣeḍ.
+
+[interface.mobile.feedback.label-feedback]
+original=Feedback
+translation=Tasedmirt
+
+[interface.mobile.feedback.label-feedback-desc]
+original=Are you enjoying Obsidian? Help us by giving it a rating.
+translation=Iɛeǧb-ak·am Obsidian? Allel-aɣ s tikci n wazal.
+
+[interface.mobile.feedback.action-rate]
+original=Rate the app
+translation=Fk azal i usnas
+
+[interface.mobile.feedback.action-dismiss]
+original=Dismiss
+translation=Kkes
+
+[interface.mobile.icloud-startup.msg-reload-needed]
+original=Configuration files updated from iCloud, reload required
+translation=Ifuyla n twila ttumuccḍen seg iCloud, tulsa usali yettwasera
+
+[interface.mobile.icloud-startup.action-reload]
+original=Reload
+translation=Ales asali
+
+[interface.help-screen.label-official-help-site]
+original=Official help site
+translation=Asmel unṣib n tallalt
+
+[interface.help-screen.label-official-help-site-desc]
+original=Read the official help documentation of Obsidian, available in multiple languages.
+translation=Ɣeṛ isemliyen unṣiben n tallalt n Obsidian, yestufan s waṭas n tutlayin.
+
+[interface.help-screen.action-visit]
+original=Visit
+translation=Rzu
+
+[interface.help-screen.label-discord-chat]
+original=Discord chat
+translation=Ameslay Discord
+
+[interface.help-screen.label-discord-chat-desc]
+original=Discord is the best place to chat with other experienced Obsidian users from around the world.
+translation=Discord d amkan yufraren i udiwenni d yiseqdacen nniḍen irmitan n Obsidian seg umaḍal merra.
+
+[interface.help-screen.action-join]
+original=Join
+translation=Lteɣ
+
+[interface.help-screen.label-forum]
+original=Official forum
+translation=Anmager unṣib
+
+[interface.help-screen.label-forum-desc]
+original=Help each other, post feature requests, report bugs, and have in-depth discussions about knowledge management.
+translation=Mɛawanet gar-awen, sutar tiseɣnin, mel-d tuccḍiwin, yerna xdemet ameslay lqayen ɣef usefrek n tmusni.
+
+[interface.help-screen.label-sandbox-vault]
+original=Sandbox vault
+translation=Akaram n weḥraz n tenkult n yijdi
+
+[interface.help-screen.label-sandbox-vault-desc]
+original=Play around and experiment with various features. Please note your changes will not be saved.
+translation=Urar yerna ɛreḍ aṭas n tseɣnin. Ttxil-k·m ḥṣu belli ibeddilen-ik·im ur ttwaḥerzen ara.
+
+[commands.save-file]
+original=Save current file
+translation=Sekles afaylu amiran
+
+[commands.download-attachments]
+original=Download attachments for current file
+translation=Sider imeddayen i ufaylu amiran 
+
+[commands.follow-cursor-link]
+original=Follow link under cursor
+translation=Ḍfaṛ aseɣwen ddaw tḥnaccaṭ
+
+[commands.open-cursor-link-in-new-tab]
+original=Open link under cursor in new tab
+translation=Ldi aseɣwen ddaw tḥnaccaṭ deg yiccer amaynut
+
+[commands.open-cursor-link-to-the-right]
+original=Open link under cursor to the right
+translation=Ldi aseɣwen ddaw tḥnaccaṭ ɣer yeffus 
+
+[commands.open-cursor-link-in-new-window]
+original=Open link under cursor in new window
+translation=Ldi aseɣwen ddaw tḥnaccaṭ deg usfaylu amaynut
+
+[commands.navigate-tab-above]
+original=Focus on tab group above
+translation=Asaḍas ɣef ugraw n waccaren ɣer ufella 
+
+[commands.navigate-tab-below]
+original=Focus on tab group below
+translation=Asaḍas ɣef ugraw n waccaren ɣer ddaw-a 
+
+[commands.navigate-tab-left]
+original=Focus on tab group to the left
+translation=Asaḍas ɣef ugraw n waccaren ɣer zelmaḍ
+
+[commands.navigate-tab-right]
+original=Focus on tab group to the right
+translation=Asaḍas ɣef ugraw n waccaren ɣer yeffus 
+
+[commands.toggle-pin]
+original=Toggle pin
+translation=Qluqel amsenṭeḍ
+
+[commands.split-right]
+original=Split right
+translation=Bḍu ɣer yeffus 
+
+[commands.split-down]
+original=Split down
+translation=Bḍu ɣer wadda
+
+[commands.toggle-stacked-tabs]
+original=Toggle stacked tabs
+translation=Senfel icceran isemnennayen 
+
+[commands.toggle-readable-line-length]
+original=Toggle readable line length
+translation=Senfel teɣzi n yizirig yettwaɣren 
+
+[commands.toggle-line-numbers]
+original=Toggle line numbers
+translation=Senfel uṭṭunen n yizirigen 
+
+[commands.navigate-back]
+original=Navigate back
+translation=Uɣal ɣer deffir 
+
+[commands.navigate-forward]
+original=Navigate forward
+translation=Ddu ɣer zdat 
+
+[commands.toggle-light-dark-mode]
+original=Toggle light/dark mode
+translation=Senfel askar aceɛlal/ubrik
+
+[commands.change-theme]
+original=Change theme...
+translation=Beddel asentel...
+
+[commands.change-vault]
+original=Change vault...
+translation=Beddel akaram n weḥraz...
+
+[commands.open-vault]
+original=Open vault...
+translation=Ldi akaram n weḥraz...
+
+[commands.manage-vaults]
+original=Manage vaults
+translation=Sefrek ikaramen n weḥraz 
+
+[commands.search-current-file]
+original=Search current file
+translation=Nadi deg ufaylu amiran 
+
+[commands.search-replace-current-file]
+original=Search & replace in current file
+translation=Nadi d usemselsi deg ufaylu amiran 
+
+[commands.add-property]
+original=Add file property
+translation=Rnu arat n ufaylu 
+
+[commands.label-sort-property-a-to-z]
+original=Name (A to Z)
+translation=Isem (A ar Z) 
+
+[commands.label-sort-property-z-to-a]
+original=Name (Z to A)
+translation=Isem (Z ar A) 
+
+[commands.add-alias]
+original=Add alias
+translation=Rnu tazaẓlut 
+
+[commands.clear-properties]
+original=Clear file properties
+translation=Sfeḍ iraten n ufaylu 
+
+[commands.open-settings]
+original=Open settings
+translation=Ldi iɣewwaren 
+
+[commands.open-help]
+original=Open help
+translation=Ldi tallalt 
+
+[commands.toggle-edit]
+original=Toggle editing/reading view
+translation=Senfel taskant n teẓrigt/tɣuri 
+
+[commands.toggle-source-mode]
+original=Toggle Live Preview/Source mode
+translation=Senfel taskant srid/askar n uɣbalu
+
+[commands.delete-current-file]
+original=Delete current file
+translation=Kkes afaylu amiran 
+
+[commands.new-tab]
+original=New tab
+translation=Iccer amaynut
+
+[commands.new-window]
+original=New window
+translation=Asfaylu amaynut 
+
+[commands.show-trash]
+original=Show trash
+translation=Sken iḍumman
+
+[commands.close-all-tabs]
+original=Close all tabs
+translation=Mdel akk icceran
+
+[commands.close-active-tab]
+original=Close current tab
+translation=Mdel iccer amiran 
+
+[commands.close-others-in-tab-group]
+original=Close others in tab group
+translation=Mdel wiyaḍ deg ugraw n yicceran
+
+[commands.close-other-tabs]
+original=Close all other tabs
+translation=Mdel akk icceran nniḍen
+
+[commands.close-tab-group]
+original=Close this tab group
+translation=Mdel agraw-a n yicceran 
+
+[commands.toggle-left-sidebar]
+original=Toggle left sidebar
+translation=Senfel tafeggagt tidisant ɣer zelmeḍ 
+
+[commands.toggle-ribbon]
+original=Toggle ribbon
+translation=Senfel tasfift 
+
+[commands.toggle-right-sidebar]
+original=Toggle right sidebar
+translation=Senfel tafeggagt tidisant ɣer yeffus 
+
+[commands.toggle-default-new-tab-mode]
+original=Toggle default mode for new tabs
+translation=Senfel askar amezwer i yicceran imaynuten 
+
+[commands.add-cursor-above]
+original=Add cursor above
+translation=Rnu taḥnaccaṭ ufella 
+
+[commands.add-cursor-below]
+original=Add cursor below
+translation=Rnu taḥnaccaṭ ddaw-a 
+
+[commands.focus-editor]
+original=Focus on last note
+translation=Asaḍas ɣef tezmilt taneggarut
+
+[commands.toggle-fold-properties]
+original=Toggle fold properties in current file
+translation=Senfel afnaẓ n yiraten deg ufaylu amiran 
+
+[commands.toggle-fold]
+original=Toggle fold on the current line
+translation=Senfel afnaẓ ɣef yizirig amiran 
+
+[commands.fold-all]
+original=Fold all headings and lists
+translation=Fneẓ akk tisenṭa d tebdarin 
+
+[commands.unfold-all]
+original=Unfold all headings and lists
+translation=Fser akk tisenṭa d tebdarin 
+
+[commands.fold-more]
+original=Fold more
+translation=Fneẓ ugar 
+
+[commands.fold-less]
+original=Fold less
+translation=Fneẓ drus 
+
+[commands.swap-line-up]
+original=Move line up
+translation=Sali izirig 
+
+[commands.swap-line-down]
+original=Move line down
+translation=Sider izirig 
+
+[commands.remove-heading]
+original=Remove heading
+translation=Kkes tasenṭit 
+
+[commands.toggle-heading]
+original=Set as heading {{level}}
+translation=Sbadu d tasenṭit {{level}}
+
+[commands.toggle-bold]
+original=Toggle bold
+translation=Qluqel azuran 
+
+[commands.toggle-italics]
+original=Toggle italic
+translation=Qluqel uknan
+
+[commands.toggle-highlight]
+original=Toggle highlight
+translation=Qluqel asebruraq
+
+[commands.toggle-comments]
+original=Toggle comment
+translation=Qluqel awennit 
+
+[commands.clear-formatting]
+original=Clear formatting
+translation=Sfeḍ amsal 
+
+[commands.insert-link]
+original=Insert Markdown link
+translation=Ger aseɣwen Markdown 
+
+[commands.toggle-spellcheck]
+original=Toggle spellcheck
+translation=Qluqel asenqed n teɣdirawt
+
+[commands.delete-paragraph]
+original=Delete paragraph
+translation=Kkes taseddart
+
+[commands.toggle-checklist]
+original=Toggle checkbox status
+translation=Qluqel addad n tenkalt n usenqed 
+
+[commands.cycle-list-checklist]
+original=Cycle bullet/checkbox
+translation=Ales tililect/tankalt n usenqed 
+
+[commands.insert-callout]
+original=Insert callout
+translation=Ger asiwel 
+
+[commands.insert-code-block]
+original=Insert code block
+translation=Ger iḥder n tengalt 
+
+[commands.insert-math-block]
+original=Insert math block
+translation=Ger iḥder n tusnakt 
+
+[commands.insert-horizontal-rule]
+original=Insert horizontal rule
+translation=Ger alugan aglawan
+
+[commands.insert-table]
+original=Insert table
+translation=Ger tafelwit 
+
+[commands.insert-footnote]
+original=Insert footnote
+translation=Ger tazmilt n uḍar usebter
+
+[commands.edit-file-title]
+original=Rename file
+translation=Beddel isem n ufaylu 
+
+[commands.copy-path]
+original=Copy current file path from vault folder
+translation=Nɣel abrid n ufaylu amiran seg ukaram n weḥraz 
+
+[commands.copy-full-path]
+original=Copy current file path from system root
+translation=Nɣel abrid n ufaylu amiran seg uẓaṛ n unagraw 
+
+[commands.copy-url]
+original=Copy Obsidian URL for current file
+translation=Nɣel URL n Obsidian i ufaylu amiran 
+
+[commands.export-pdf]
+original=Export to PDF...
+translation=Sifeḍ ɣer PDF... 
+
+[commands.reload]
+original=Reload app without saving
+translation=Ales asali n usnas war asekles
+
+[commands.undo-close-tab]
+original=Undo close tab
+translation=Semmet amdal n yiccer 
+
+[commands.context-menu]
+original=Show context menu under cursor
+translation=Sken amuɣ asatal ddaw tḥnaccaṭ 
+
+[commands.show-debug-info]
+original=Show debug info
+translation=Sken tilɣa n useɣti 
+
+[commands.open-sandbox-vault]
+original=Open sandbox vault
+translation=Ldi akaram n weḥraz n tenkult n yijdi
+
+[commands.always-on-top]
+original=Toggle window always on top
+translation=Qluqel asfaylu dima ufella 
+
+[commands.zoom-in]
+original=Zoom in
+translation=Semɣer
+
+[commands.zoom-out]
+original=Zoom out
+translation=Semẓi
+
+[commands.reset-zoom]
+original=Reset zoom
+translation=Wennez asemɣer 
+
+[commands.toggle-preview]
+original=Toggle reading view
+translation=Qluqel taskant n tɣuri
+
+[commands.move-to-new-window]
+original=Move current tab to new window
+translation=Smutti iccer amiran ɣer usfaylu amaynut 
+
+[commands.open-in-new-window]
+original=Open current tab in new window
+translation=Ldi iccer amiran deg usfaylu amaynut 
+
+[commands.rename-current-file]
+original=Rename current file
+translation=Beddel isem n ufaylu amiran 
+
+[commands.go-to-prev-tab]
+original=Go to previous tab
+translation=Ddu ɣer yiccer uzwir
+
+[commands.go-to-next-tab]
+original=Go to next tab
+translation=Ddu ɣer yiccer uḍfir
+
+[commands.go-to-last-tab]
+original=Go to last tab
+translation=Ddu ɣer yiccer aneggaru 
+
+[commands.go-to-nth-tab]
+original=Go to tab #{{n}}
+translation=Ddu ɣer yiccer #{{n}}
+
+[commands.show-release-notes]
+original=Show release notes
+translation=Sken tizmilin n lqem
+
+[dialogue.label-link-affected]
+original=This will affect {{links}} in {{files}}.
+translation=Aya ad iḥaz {{links}} deg {{files}}.
+
+[dialogue.msg-updated-links]
+original=Updated {{links}} in {{files}}.
+translation=Aleqqem n {{links}} deg {{files}}. 
+
+[dialogue.label-update-links]
+original=Update links
+translation=Mucceḍ iseɣwan 
+
+[dialogue.label-confirm-update-link-to-file]
+original=Do you want to update internal links that link to this file?
+translation=Tebɣiḍ ad tmucceḍeḍ iseɣwan igensanen i yeqqnen ɣer ufaylu-a? 
+
+[dialogue.button-always-update]
+original=Always update
+translation=Mucceḍ dima 
+
+[dialogue.button-just-once]
+original=Just once
+translation=Yiwet n tikkelt kan
+
+[dialogue.button-do-not-update]
+original=Do not update
+translation=Ur smuccuḍ ara 
+
+[dialogue.label-confirm-deletion]
+original=Are you sure you want to delete “{{filename}}”?
+translation=Tebɣiḍ s tidet ad tekksed “{{filename}}”? 
+
+[dialogue.label-move-to-system-trash]
+original=It will be moved to your system trash.
+translation=Ad yettwasmutti ɣer yiḍumman n unagraw-inek·inem. 
+
+[dialogue.label-move-to-vault-trash]
+original=It will be moved to your Obsidian trash, which is located in the “.trash” hidden folder in your vault.
+translation=Ad yettwasmutti ɣer yiḍumman-inek·inem n Obsidian, yezgan deg ukaram uffir “.trash” deg ukaram-ik·im n weḥraz. 
+
+[dialogue.label-permanent-delete]
+original=The file will be permanent deleted.
+translation=Afaylu ad yettwakkes s wudem imezgi. 
+
+[dialogue.label-non-empty-folder]
+original=This folder is not empty.
+translation=Akaram-a ur yelli ara d ilem. 
+
+[dialogue.label-delete-folder-warning]
+original=If you continue, all files inside this folder will be deleted.
+translation=Ma tkemmleḍ, akk ifuyla yellan deg ukaram-a ad ttwakksen. 
+
+[dialogue.label-delete-folder]
+original=Delete folder
+translation=Kkes akaram 
+
+[dialogue.button-delete]
+original=Delete
+translation=Kkes 
+
+[dialogue.label-do-not-ask-again]
+original=Don't ask again
+translation=Ur d-steqsay ara tikkelt nniḍen
+
+[dialogue.label-existing-backlink]
+original=There is currently {{count}} link pointing to this file.
+translation=Yella tura {{count}} n useɣwen i d-yemmalen ɣer ufaylu-a. 
+
+[dialogue.label-existing-backlink_plural]
+original=There are currently {{count}} links pointing to this file.
+translation=Llan tura {{count}} n yiseɣwan i d-yemmalen ɣer ufaylu-a.
+
+[dialogue.label-delete-file]
+original=Delete file
+translation=Kkes afaylu
+
+[dialogue.label-download-attachments]
+original=Download attachments
+translation=Sider imeddayen
+
+[dialogue.label-no-attachments]
+original=There are no external attachments in this note.
+translation=Ulac imeddayen uffiɣen deg tezmilt-a.
+
+[dialogue.label-downloaded-attachments]
+original=Downloaded {{count}} attachment.
+translation=Yettwasider {{count}} umedday.
+
+[dialogue.label-downloaded-attachments_plural]
+original=Downloaded {{count}} attachments.
+translation=Ttwasidren {{count}} n yimeddayen.
+
+[dialogue.msg-files-updated]
+original=Updated {{count}} file.
+translation=Yettwamucceḍ {{count}} ufaylu.
+
+[dialogue.msg-files-updated_plural]
+original=Updated {{count}} files.
+translation=Ttwamuccḍen {{count}} n yifuyla.
+
+[dialogue.msg-files-reverted]
+original=Reverted changes to {{count}} file.
+translation=Ttwassuɣalen yibeddilen ɣer {{count}} ufaylu.
+
+[dialogue.msg-files-reverted_plural]
+original=Reverted changes to {{count}} files.
+translation=Ttwassuɣalen yibeddilen ɣer {{count}} n yifuyla.
+
+[dialogue.msg-offline]
+original=No internet connection
+translation=Ulac tuqqna ɣer Internet
+
+[dialogue.msg-loading]
+original=Loading...
+translation=Asali...
+
+[dialogue.button-manage]
+original=Manage
+translation=Sefrek
+
+[dialogue.button-view]
+original=View
+translation=Sken
+
+[dialogue.button-confirm]
+original=Confirm
+translation=Sentem
+
+[dialogue.button-cancel]
+original=Cancel
+translation=Semmet
+
+[dialogue.button-skip]
+original=Skip
+translation=Zgel
+
+[dialogue.button-download]
+original=Download
+translation=Sider
+
+[dialogue.button-done]
+original=Done
+translation=Ifukk
+
+[dialogue.button-save]
+original=Save
+translation=Sekles
+
+[dialogue.button-stop]
+original=Stop
+translation=Ḥbes
+
+[dialogue.button-change]
+original=Change
+translation=Beddel
+
+[dialogue.button-continue]
+original=Continue
+translation=Kemmel
+
+[dialogue.button-choose]
+original=Choose
+translation=Fren
+
+[dialogue.button-retry]
+original=Retry
+translation=Ales aɛraḍ
+
+[dialogue.button-update]
+original=Update
+translation=Mucceḍ
+
+[dialogue.button-undo]
+original=Undo
+translation=Semmet
+
+[dialogue.preparing-pdf]
+original=Preparing PDF...
+translation=Aheggi n PDF...
+
+[dialogue.label-rename-file]
+original=Note title
+translation=Azwel n tezmilt
+
+[dialogue.label-rename-file-generic]
+original=File name
+translation=Isem n ufaylu
+
+[dialogue.label-new-name]
+original=New name
+translation=Isem amaynut
+
+[dialogue.label-error]
+original=Error
+translation=Tuccḍa
+
+[dialogue.label-selected]
+original=Selected
+translation=Yettwafren
+
+[dialogue.msg-rename-success]
+original=Successfully renamed file.
+translation=Asnifel n yisem n ufaylu yedda akken iwata.
+
+[dialogue.msg-merge-failed]
+original=Failed to merge notes: {{message}}
+translation=Yecceḍ wezday n tezmiltin: {{message}}
+
+[dialogue.msg-file-or-folder-not-found]
+original=The file or folder “{{path}}” does not exist.
+translation=Afaylu neɣ akaram “{{path}}” ulac-it.
+
+[dialogue.msg-heading-empty]
+original=Heading cannot be empty
+translation=Tasenṭit ur tezmir ara ad tili d tilemt
+
+[dialogue.msg-block-id-empty]
+original=Block ID cannot be empty
+translation=Asulay n yiḥder ur yezmir ara ad yili d ilem
+
+[dialogue.msg-block-id-invalid]
+original=Block ID can only contain alphanumeric characters or dash
+translation=Asulay n yiḥder yezmer ad yesɛu kan isekkilen igmumḍinen neɣ ajeṛṛid
+
+[dialogue.label-rename-heading]
+original=Rename heading
+translation=Snifel isem n tsenṭit
+
+[dialogue.label-rename-blockid]
+original=Rename block ID
+translation=Beddel isem n usulay n yiḥder
+
+[dialogue.orphan-attachments-title]
+original=Delete file attachments?
+translation=Kkes imeddayen n ufaylu?
+
+[dialogue.orphan-attachments-desc]
+original=This attachment is no longer used in any notes. Would you like to delete it?
+translation=Amedday-a ur yettuseqdac ara dayen deg tezmiltin. Tebɣiḍ ad t-tekkseḍ?
+
+[dialogue.orphan-attachments-desc_plural]
+original=These {{count}} attachments are no longer used in any notes. Would you like to delete them?
+translation={{count}} n yimeddayen-a ur ttuseqdacen ara dayen deg tezmiltin. Tebɣiḍ ad ten-tekkseḍ?
+
+[dialogue.tooltip-file-tree]
+original=File tree
+translation=Aseklu n yifuyla
+
+[dialogue.tooltip-gallery]
+original=Gallery
+translation=Agalis n tugniwin
+
+[menu-items.new-file]
+original=New Note
+translation=Tazmilt Tamaynut
+
+[menu-items.new-file-to-the-right]
+original=New Note to the Right
+translation=Tazmilt Tamaynut ɣer Yeffus
+
+[menu-items.new-tab]
+original=New Tab
+translation=Iccer Amaynut
+
+[menu-items.new-window]
+original=New Window
+translation=Asfaylu Amaynut
+
+[menu-items.open-switcher]
+original=Open Quickly...
+translation=Ldi s Urured...
+
+[menu-items.open-vault]
+original=Open Vault...
+translation=Ldi Akaram n Weḥraz...
+
+[menu-items.close-tab]
+original=Close Tab
+translation=Mdel Iccer
+
+[menu-items.close-window]
+original=Close Window
+translation=Mdel Asfaylu
+
+[menu-items.find]
+original=Find
+translation=Nadi
+
+[menu-items.replace]
+original=Replace
+translation=Semselsi
+
+[menu-items.insert-callout]
+original=Callout
+translation=Tiɣṛi
+
+[menu-items.insert-markdown-link]
+original=Markdown Link
+translation=Aseɣwen Markdown
+
+[menu-items.insert-wikilink]
+original=Link
+translation=Aseɣwen
+
+[menu-items.set-heading]
+original=Heading {{level}}
+translation=Tasenṭit {{level}}
+
+[menu-items.no-heading]
+original=Body
+translation=Tafekka
+
+[menu-items.insert-quote]
+original=Quote
+translation=Abdar
+
+[menu-items.export-pdf]
+original=Export To PDF...
+translation=Sifeḍ ɣer PDF...
+
+[menu-items.insert-attachment]
+original=Insert Attachment...
+translation=Ger Amedday...
+
+[menu-items.insert-codeblock]
+original=Code Block
+translation=Iḥder n Tengalt
+
+[menu-items.insert-math-block]
+original=Math Block
+translation=Iḥder n Tusnakt
+
+[menu-items.insert-table]
+original=Table
+translation=Tafelwit
+
+[menu-items.insert-footnote]
+original=Footnote
+translation=Awennit n uḍar usebter
+
+[menu-items.inline-title]
+original=Inline title
+translation=Azwel deg izirig
+
+[menu-items.line-numbers]
+original=Line numbers
+translation=Uṭṭunen n yizirigen
+
+[menu-items.toggle-bullet-list]
+original=Bullet List
+translation=Tabdart s Tlilac
+
+[menu-items.toggle-numbered-list]
+original=Numbered List
+translation=Tabdart s Wuṭṭunen
+
+[menu-items.toggle-checklist]
+original=Task List
+translation=Tabdart n Tiwuriwin
+
+[menu-items.toggle-bold]
+original=Bold
+translation=Azuran
+
+[menu-items.toggle-code]
+original=Code
+translation=Tangalt
+
+[menu-items.toggle-comment]
+original=Comment
+translation=Awennit
+
+[menu-items.toggle-italics]
+original=Italics
+translation=Uknan
+
+[menu-items.toggle-inline-math]
+original=Math
+translation=Tusnakt
+
+[menu-items.toggle-highlight]
+original=Highlight
+translation=Asebrureq
+
+[menu-items.toggle-strikethrough]
+original=Strikethrough
+translation=Yettwajerreḍ
+
+[menu-items.toggle-comments]
+original=Comment
+translation=Awennit
+
+[menu-items.folding-menu]
+original=Folding
+translation=Afnaẓ
+
+[menu-items.fold-all]
+original=Fold All
+translation=Fneẓ Akk
+
+[menu-items.unfold-all]
+original=Unfold All
+translation=Fser Akk
+
+[menu-items.fold-more]
+original=Fold More
+translation=Fneẓ Ugar
+
+[menu-items.fold-less]
+original=Fold Less
+translation=Fneẓ Drus
+
+[menu-items.source-mode]
+original=Source Mode
+translation=Askar n Uɣbalu
+
+[menu-items.reading-view]
+original=Reading View
+translation=Taskant n Tɣuri
+
+[menu-items.show-debug-info]
+original=Show Debug Info
+translation=Sken Talɣut n Useɣti
+
+[menu-items.open-sandbox]
+original=Open Sandbox Vault
+translation=Ldi Akaram n Weḥraz n Tenkult n Yijdi
+
+[menu-items.move-to-new-window]
+original=Move To New Window
+translation=Smutti ɣer Usfaylu Amaynut
+
+[menu-items.navigate-back]
+original=Navigate Back
+translation=Uɣal ɣer Deffir
+
+[menu-items.navigate-forward]
+original=Navigate Forward
+translation=Ddu ɣer Zdat
+
+[menu-items.toggle-left-sidebar]
+original=Left Sidebar
+translation=Agalis n Tama Tazelmaṭ
+
+[menu-items.toggle-right-sidebar]
+original=Right Sidebar
+translation=Agalis n Tama Tayeffust
+
+[menu-items.toggle-ribbon]
+original=Ribbon
+translation=Tasfift
+
+[menu-items.split-right]
+original=Split Right
+translation=Bḍu ɣer Yeffus
+
+[menu-items.split-down]
+original=Split Down
+translation=Bḍu ɣer Wadda
+
+[menu-items.release-notes]
+original=Release Notes
+translation=Iwenniten n Lqem
+
+[plugins.name]
+original=Plugins
+translation=Isiɣzaf
+
+[plugins.file-explorer.name]
+original=Files
+translation=Ifuyla
+
+[plugins.file-explorer.desc]
+original=Browse the files and folders in your vault.
+translation=Snirem ifuyla d yikaramen deg ukaram-ik n weḥraz.
+
+[plugins.file-explorer.action-open]
+original=Open file explorer
+translation=Ldi anaram n yifuyla
+
+[plugins.file-explorer.action-show]
+original=Show file explorer
+translation=Sken anaram n yifuyla
+
+[plugins.file-explorer.action-create-note]
+original=Create new note
+translation=Snulfu-d tazmilt tamaynut
+
+[plugins.file-explorer.action-create-folder]
+original=Create new folder
+translation=Snulfu-d akaram amaynut
+
+[plugins.file-explorer.action-create-note-in-current-tab]
+original=Create new note in current tab
+translation=Snulfu-d tazmilt tamaynut deg yiccer amiran
+
+[plugins.file-explorer.action-create-note-to-the-right]
+original=Create note to the right
+translation=Snulfu-d tazmilt ɣer yeffus
+
+[plugins.file-explorer.action-auto-reveal]
+original=Auto-reveal current file
+translation=Sken s wudem awurman afaylu amiran
+
+[plugins.file-explorer.action-collapse-all]
+original=Collapse all
+translation=Fneẓ akk
+
+[plugins.file-explorer.action-expand-all]
+original=Expand all
+translation=Semɣer akk
+
+[plugins.file-explorer.action-new-note]
+original=New note
+translation=Tazmilt tamaynut
+
+[plugins.file-explorer.action-new-folder]
+original=New folder
+translation=Akaram amaynut
+
+[plugins.file-explorer.action-change-sort]
+original=Change sort order
+translation=Beddel amizzwer n wefran
+
+[plugins.file-explorer.action-reveal-file]
+original=Reveal file in navigation
+translation=Sken afaylu deg tunigin
+
+[plugins.file-explorer.action-reveal-active-file]
+original=Reveal current file in navigation
+translation=Sken afaylu amiran deg tunigin
+
+[plugins.file-explorer.command-make-a-copy]
+original=Make a copy of the current file
+translation=Xdem anɣel n ufaylu amiran
+
+[plugins.file-explorer.command-make-a-copy-mac]
+original=Duplicate current file
+translation=Sleg afaylu amiran
+
+[plugins.file-explorer.command-move-file]
+original=Move current file to another folder
+translation=Smutti afaylu amiran ɣer ukaram nniḍen
+
+[plugins.file-explorer.action-new-folder-with-count]
+original=New folder with selection ({{count}} item)
+translation=Akaram amaynut s tefrayt ({{count}} uferdis)
+
+[plugins.file-explorer.action-new-folder-with-count_plural]
+original=New folder with selection ({{count}} items)
+translation=Akaram amaynut s tefrayt ({{count}} yiferdisen)
+
+[plugins.file-explorer.action-move-file]
+original=Move file to...
+translation=Smutti afaylu ɣer...
+
+[plugins.file-explorer.action-move-folder]
+original=Move folder to...
+translation=Smutti akaram ɣer...
+
+[plugins.file-explorer.action-move-items]
+original=Move {{count}} items to...
+translation=Smutti {{count}} yiferdisen ɣer...
+
+[plugins.file-explorer.prompt-type-folder]
+original=Type a folder
+translation=Aru isem n ukaram
+
+[plugins.file-explorer.label-no-folders]
+original=No existing folders found.
+translation=Ulac ikaramen yellan i yettwafan.
+
+[plugins.file-explorer.instruction-navigate]
+original=to navigate
+translation=i tunigin
+
+[plugins.file-explorer.instruction-move]
+original=to move
+translation=i usmutti
+
+[plugins.file-explorer.instruction-create]
+original=to create
+translation=i wesnulfu
+
+[plugins.file-explorer.instruction-dismiss]
+original=to dismiss
+translation=i tukksa
+
+[plugins.file-explorer.label-sort-a-to-z]
+original=File name (A to Z)
+translation=Isem n ufaylu (A ar Z)
+
+[plugins.file-explorer.label-sort-z-to-a]
+original=File name (Z to A)
+translation=Isem n ufaylu (Z ar A)
+
+[plugins.file-explorer.label-sort-new-to-old]
+original=Modified time (new to old)
+translation=Akud n ubeddel (amaynut ar uqdim)
+
+[plugins.file-explorer.label-sort-old-to-new]
+original=Modified time (old to new)
+translation=Akud n ubeddel (aqdim ar umaynut)
+
+[plugins.file-explorer.label-sort-created-old-to-new]
+original=Created time (old to new)
+translation=Akud n wesnulfu (aqdim ar umaynut)
+
+[plugins.file-explorer.label-sort-created-new-to-old]
+original=Created time (new to old)
+translation=Akud n wesnulfu (amaynut ar uqdim)
+
+[plugins.file-explorer.menu-opt-new-note]
+original=New note
+translation=Tazmilt tamaynut
+
+[plugins.file-explorer.menu-opt-new-folder]
+original=New folder
+translation=Akaram amaynut
+
+[plugins.file-explorer.menu-opt-rename]
+original=Rename...
+translation=Snifel isem...
+
+[plugins.file-explorer.menu-opt-delete]
+original=Delete
+translation=Kkes
+
+[plugins.file-explorer.menu-opt-make-copy]
+original=Make a copy
+translation=Xdem anɣel
+
+[plugins.file-explorer.menu-opt-make-copy-mac]
+original=Duplicate
+translation=Sleg
+
+[plugins.file-explorer.msg-invalid-characters]
+original=File name cannot contain any of these characters: 
+translation=Isem n ufaylu ur yezmir ara ad yesɛu isekkilen-a: 
+
+[plugins.file-explorer.msg-unsafe-characters]
+original=Links will not work with file names containing any of these characters: 
+translation=Iseɣwan ur xeddmen ara s yismawen n yifuyla yesɛan isekkilen-a: 
+
+[plugins.file-explorer.msg-file-already-exists]
+original=There's already a file with the same name
+translation=Yella yakan ufaylu s yisem-a
+
+[plugins.file-explorer.msg-empty-file-name]
+original=File name cannot be empty.
+translation=Isem n ufaylu ur yezmir ara ad yili d ilem.
+
+[plugins.file-explorer.msg-bad-dotfile]
+original=File name must not start with a dot.
+translation=Isem n ufaylu ur yezmir ara ad yebdu s tneqqiṭ.
+
+[plugins.file-explorer.tooltip-modified-time]
+original=Last modified at {{time}}
+translation=Abeddel aneggaru deg {{time}}
+
+[plugins.file-explorer.tooltip-created-time]
+original=Created at {{time}}
+translation=Yennulfa-d deg {{time}}
+
+[plugins.file-explorer.label-untitled-file]
+original=Untitled
+translation=War azwel
+
+[plugins.file-explorer.label-untitled-folder]
+original=Untitled
+translation=War azwel
+
+[plugins.file-explorer.msg-set-attachment-folder]
+original=Attachments will be saved to “{{path}}” from now on.
+translation=Imeddayen ad ttwaḥerzen deg “{{path}}” seg tura d asawen.
+
+[plugins.search.name]
+original=Search
+translation=Anadi
+
+[plugins.search.desc]
+original=Search for a keyword in all the notes.
+translation=Nadi awalen yufraren deg tezmiltin meṛṛa.
+
+[plugins.search.action-open-search]
+original=Search in all files
+translation=Nadi deg yifuyla meṛṛa
+
+[plugins.search.label-collapse-results]
+original=Collapse results
+translation=Fneẓ igmaḍ
+
+[plugins.search.label-match-case]
+original=Match case
+translation=Qadeṛ isekkilen meqqren/mezziyen
+
+[plugins.search.label-explain-search-term]
+original=Explain search terms
+translation=Ssefhem awalen n unadi
+
+[plugins.search.label-more-context]
+original=Show more context
+translation=Sken ugar n usatal
+
+[plugins.search.label-result-count]
+original={{count}} result
+translation={{count}} ugmuḍ
+
+[plugins.search.label-result-count_plural]
+original={{count}} results
+translation={{count}} yigmaḍ
+
+[plugins.search.label-toggle-search-settings]
+original=Search settings
+translation=Iɣewwaren n unadi
+
+[plugins.search.prompt-start-search]
+original=Search...
+translation=Nadi...
+
+[plugins.search.label-match-text]
+original=Matches text: 
+translation=Yemṣada d weḍris: 
+
+[plugins.search.label-match-regex]
+original=Matches regex: 
+translation=Yemṣada d regex: 
+
+[plugins.search.label-match-exact-text]
+original=Contains exact text: 
+translation=Yesɛa aḍris unṣib: 
+
+[plugins.search.label-match-greater-than]
+original=Greater than: 
+translation=Yugar: 
+
+[plugins.search.label-match-less-than]
+original=Less than: 
+translation=Yeqqel: 
+
+[plugins.search.label-match-true]
+original=Is true
+translation=D tidet
+
+[plugins.search.label-match-false]
+original=Is false
+translation=D ucciḍ
+
+[plugins.search.label-match-empty]
+original=Is empty
+translation=D ilem
+
+[plugins.search.label-match-property]
+original=Contains property:
+translation=Yesɛa arat:
+
+[plugins.search.label-match-all]
+original=Match all of: 
+translation=Mṣada d wakk: 
+
+[plugins.search.label-match-any]
+original=Match any of: 
+translation=Mṣada d kra seg: 
+
+[plugins.search.label-excluding]
+original=Excluding: 
+translation=Stixeṛ: 
+
+[plugins.search.label-case-sensitive]
+original=Case sensitive
+translation=Qadeṛ isekkilen meqqren/mezziyen
+
+[plugins.search.label-case-insensitive]
+original=Case insensitive
+translation=Ur tqadaṛ ara isekkilen meqqren/mezziyen
+
+[plugins.search.label-match-file-path]
+original=Match file path: 
+translation=Mṣada d ubrid n ufaylu: 
+
+[plugins.search.label-match-file-name]
+original=Match file name: 
+translation=Mṣada d yisem n ufaylu: 
+
+[plugins.search.label-match-content]
+original=Match file content: 
+translation=Mṣada d ugbur n ufaylu: 
+
+[plugins.search.label-match-task]
+original=Match task: 
+translation=Mṣada d twuri: 
+
+[plugins.search.label-match-task-todo]
+original=Match task (todo): 
+translation=Mṣada d twuri (araxdem): 
+
+[plugins.search.label-match-task-done]
+original=Match task (done): 
+translation=Mṣada d twuri (yettwaxdem): 
+
+[plugins.search.label-match-line]
+original=Match line: 
+translation=Mṣada d yizirig: 
+
+[plugins.search.label-match-block]
+original=Match block: 
+translation=Mṣada d yiḥder: 
+
+[plugins.search.label-match-section]
+original=Match section: 
+translation=Mṣada d tgezmi: 
+
+[plugins.search.label-match-tag]
+original=Match tag: 
+translation=Mṣada d tecṛeṭ: 
+
+[plugins.search.label-no-matches]
+original=No matches found.
+translation=Ulac imṣadan i yettwafan.
+
+[plugins.search.matches-with-count]
+original=... and {{count}} more match.
+translation=... d {{count}} n umṣada nniḍen.
+
+[plugins.search.matches-with-count_plural]
+original=... and {{count}} more matches.
+translation=... d {{count}} n yimṣadan nniḍen.
+
+[plugins.search.label-copy-search-results]
+original=Copy search results
+translation=Nɣel igmaḍ n unadi
+
+[plugins.search.button-copy-results]
+original=Copy results
+translation=Nɣel igmaḍ
+
+[plugins.search.msg-successfully-copied]
+original=Results copied to your clipboard.
+translation=Igmaḍ ttwanɣlen ɣer tecfawit-ik.
+
+[plugins.search.option-show-path]
+original=Show path
+translation=Sken abrid
+
+[plugins.search.option-show-path-description]
+original=Display full path of the file rather than just the file name.
+translation=Sken abrid ummid n ufaylu deg wemkan n yisem-is kan.
+
+[plugins.search.option-link-style]
+original=Link style
+translation=Aɣanib n useɣwen
+
+[plugins.search.option-link-style-description]
+original=Optionally turn each file result in to a link.
+translation=Err yal agmuḍ n ufaylu d aseɣwen ma tebɣiḍ.
+
+[plugins.search.option-choice-link-style-none]
+original=None
+translation=Ulac
+
+[plugins.search.option-choice-link-style-wikilink]
+original=Wikilink
+translation=Wikilink
+
+[plugins.search.option-choice-link-style-markdown-link]
+original=Markdown link
+translation=Aseɣwen Markdown
+
+[plugins.search.option-list-prefix]
+original=List prefix
+translation=Adat n tebdart
+
+[plugins.search.option-list-prefix-description]
+original=Optionally add a list item prefix to each file result.
+translation=Rnu adat n uferdis n tebdart i yal agmuḍ n ufaylu ma tebɣiḍ.
+
+[plugins.search.option-choice-list-style-none]
+original=None
+translation=Ulac
+
+[plugins.search.option-choice-list-style-dash]
+original=Dash (-)
+translation=Ajeṛṛid (-)
+
+[plugins.search.option-choice-list-style-asterisk]
+original=Asterisk (*)
+translation=Itri (*)
+
+[plugins.search.option-choice-list-style-numbered]
+original=Numbered
+translation=S wuṭṭunen
+
+[plugins.search.tooltip-clear-search]
+original=Clear search
+translation=Sfeḍ anadi
+
+[plugins.search.label-search-options]
+original=Search options
+translation=Tixtiṛiyin n unadi
+
+[plugins.search.label-properties-group]
+original=Properties
+translation=Iraten
+
+[plugins.search.label-tags-group]
+original=Tags
+translation=Ticraḍ
+
+[plugins.search.tooltip-read-more]
+original=Read more
+translation=Ɣeṛ ugar
+
+[plugins.search.label-history]
+original=History
+translation=Azray
+
+[plugins.search.tooltip-clear-history]
+original=Clear search history
+translation=Sfeḍ azray n unadi
+
+[plugins.search.label-path-option-description]
+original=match path of the file
+translation=mṣada d ubrid n ufaylu
+
+[plugins.search.label-file-name-option-description]
+original=match file name
+translation=mṣada d yisem n ufaylu
+
+[plugins.search.label-tag-option-description]
+original=search for tags
+translation=nadi ticraḍ
+
+[plugins.search.label-line-option-description]
+original=search keywords on same line
+translation=nadi awalen yufraren deg yiwen n yizirig
+
+[plugins.search.label-section-option-description]
+original=search keywords under same heading
+translation=nadi awalen yufraren ddaw n yiwet n tsenṭit
+
+[plugins.search.label-property-option-description]
+original=match property
+translation=mṣada d urat
+
+[plugins.search.menu-opt-search-for]
+original=Search for “{{keyword}}”
+translation=Nadi ɣef “{{keyword}}”
+
+[plugins.search.menu-opt-search-in-folder]
+original=Search in folder
+translation=Nadi deg ukaram
+
+[plugins.quick-switcher.name]
+original=Quick switcher
+translation=Asenfal arurad
+
+[plugins.quick-switcher.desc]
+original=Jump to other files with your keyboard.
+translation=Ngez ɣer yifuyla nniḍen s unasiw-ik·im.
+
+[plugins.quick-switcher.short-name]
+original=Switcher
+translation=Asenfal
+
+[plugins.quick-switcher.action-open]
+original=Open quick switcher
+translation=Ldi asenfal arurad
+
+[plugins.quick-switcher.instruction-navigate]
+original=to navigate
+translation=i tunigin
+
+[plugins.quick-switcher.instruction-open]
+original=to open
+translation=i welday
+
+[plugins.quick-switcher.instruction-open-in-new-tab]
+original=to open in new tab
+translation=i welday deg yiccer amaynut
+
+[plugins.quick-switcher.instruction-open-to-the-right]
+original=to open to the right
+translation=i welday ɣer yeffus
+
+[plugins.quick-switcher.instruction-create]
+original=to create
+translation=i wesnulfu
+
+[plugins.quick-switcher.instruction-dismiss]
+original=to dismiss
+translation=i tukksa
+
+[plugins.quick-switcher.instruction-select]
+original=to select
+translation=i tefrayt
+
+[plugins.quick-switcher.label-no-note-create-new]
+original=No notes found. Enter to create a new one.
+translation=Ulac tizmiltin i yettwafan. Sekcem i wesnulfu n yiwet tamaynut.
+
+[plugins.quick-switcher.prompt-type-file-name]
+original=Find or create a note...
+translation=Af-d neɣ snulfu-d tazmilt...
+
+[plugins.quick-switcher.label-enter-to-create]
+original=Enter to create
+translation=Sekcem i wesnulfu
+
+[plugins.quick-switcher.tooltip-not-created-yet]
+original=Not created yet, select to create
+translation=Ur yennulfa ara yakan, fren i wesnulfu
+
+[plugins.quick-switcher.option-show-existing-only]
+original=Show existing only
+translation=Sken kan wid yellan
+
+[plugins.quick-switcher.option-show-existing-only-description]
+original=Only show results from existing files. Links to files that are not yet created will be hidden.
+translation=Sken kan igmaḍ seg yifuyla yellan. Iseɣwan ɣer yifuyla ur d-nennulfa ara ad ttwafferren.
+
+[plugins.quick-switcher.option-show-attachments]
+original=Show attachments
+translation=Sken imeddayen
+
+[plugins.quick-switcher.option-show-attachments-desc]
+original=Show attachment files like images, videos, and PDFs.
+translation=Sken ifuyla n yimeddayen am tugniwin, tividyutin, d PDF.
+
+[plugins.quick-switcher.option-show-all-file-types]
+original=Show all file types
+translation=Sken akk tiwsatin n yifuyla
+
+[plugins.quick-switcher.option-show-all-file-types-desc]
+original=Show all files including ones that Obsidian can't open. The file will be opened with the default app for that file type.
+translation=Sken akk ifuyla ula d wid ur yezmir ara Obsidian ad ten-ildi. Afaylu ad yeldi s usnas amezwer n tewsit-nni n ufaylu.
+
+[plugins.graph-view.name]
+original=Graph view
+translation=Taskant n udlif
+
+[plugins.graph-view.desc]
+original=Visualize the relationships between your notes.
+translation=Sken assaɣen gar tezmiltin-ik·im.
+
+[plugins.graph-view.action-open]
+original=Open graph view
+translation=Ldi taskant n udlif
+
+[plugins.graph-view.action-open-local]
+original=Open local graph
+translation=Ldi adlif adigan
+
+[plugins.graph-view.action-copy-screenshot]
+original=Copy screenshot
+translation=Nɣel tuṭṭfa n ugdil
+
+[plugins.graph-view.tab-title]
+original=Graph of {{displayText}}
+translation=Adlif n {{displayText}}
+
+[plugins.graph-view.label-filters]
+original=Filters
+translation=Tistayin
+
+[plugins.graph-view.prompt-filter-nodes]
+original=Search files...
+translation=Nadi ifuyla...
+
+[plugins.graph-view.option-depth]
+original=Depth
+translation=Alqay
+
+[plugins.graph-view.option-depth-description]
+original=Show nodes this number of links away
+translation=Sken tikerras s wemḍan-a n yiseɣwan
+
+[plugins.graph-view.option-neighbor-links]
+original=Neighbor links
+translation=Iseɣwan inaragen
+
+[plugins.graph-view.option-neighbor-links-description]
+original=Show links between neighbors
+translation=Sken iseɣwan gar yinaragen
+
+[plugins.graph-view.option-forelinks]
+original=Outgoing links
+translation=Iseɣwan uffiɣen
+
+[plugins.graph-view.option-forelinks-description]
+original=Show links to other files
+translation=Sken iseɣwan ɣer yifuyla nniḍen
+
+[plugins.graph-view.option-backlinks]
+original=Incoming links
+translation=Iseɣwan ikcamen
+
+[plugins.graph-view.option-backlinks-description]
+original=Show links from other files
+translation=Sken iseɣwan seg yifuyla nniḍen
+
+[plugins.graph-view.option-show-tags]
+original=Tags
+translation=Ticraḍ
+
+[plugins.graph-view.option-show-tags-description]
+original=Tags are linked to the files that contain them
+translation=Ticraḍ qqnent ɣer yifuyla i tent-yesɛan
+
+[plugins.graph-view.option-show-attachments]
+original=Attachments
+translation=Imeddayen
+
+[plugins.graph-view.option-show-attachments-description]
+original=Show attachments
+translation=Sken imeddayen
+
+[plugins.graph-view.option-show-existing-files-only]
+original=Existing files only
+translation=Ifuyla yellan kan
+
+[plugins.graph-view.option-show-existing-files-only-description]
+original=When enabled, links to nonexistent files are not shown
+translation=Mi yermed, iseɣwan ɣer yifuyla ur nelli ara ur d-ttbanen ara
+
+[plugins.graph-view.option-show-orphans]
+original=Orphans
+translation=Igujilen
+
+[plugins.graph-view.option-show-orphans-description]
+original=Show files that are not linked to any other file
+translation=Sken ifuyla ur neqqin ɣer ula d yiwen ufaylu nniḍen
+
+[plugins.graph-view.label-display]
+original=Display
+translation=Abeqqeḍ
+
+[plugins.graph-view.option-show-arrows]
+original=Arrows
+translation=Tineccabin
+
+[plugins.graph-view.option-show-arrows-description]
+original=Show arrows when zoomed in
+translation=Sken tineccabin mi ara tsemɣereḍ
+
+[plugins.graph-view.option-text-fade]
+original=Text fade threshold
+translation=Amnaṛ n uswexxeṛ n weḍris
+
+[plugins.graph-view.option-node-size]
+original=Node size
+translation=Tiddi n tkerrist
+
+[plugins.graph-view.option-link-thickness]
+original=Link thickness
+translation=Tuzert n useɣwen
+
+[plugins.graph-view.label-forces]
+original=Forces
+translation=Iɣallen
+
+[plugins.graph-view.option-center-force]
+original=Center force
+translation=Aɣil n tlemmast
+
+[plugins.graph-view.option-link-force]
+original=Link force
+translation=Aɣil n useɣwen
+
+[plugins.graph-view.option-link-distance]
+original=Link distance
+translation=Ameccaq n useɣwen
+
+[plugins.graph-view.option-repel-force]
+original=Repel force
+translation=Aɣil n tririt
+
+[plugins.graph-view.tooltip-open-graph-settings]
+original=Open graph settings
+translation=Ldi iɣewwaren n udlif
+
+[plugins.graph-view.msg-screenshot-copied]
+original=Screenshot copied to the clipboard.
+translation=Tuṭṭfa n ugdil tettwanɣel ɣer tecfawit.
+
+[plugins.graph-view.label-groups]
+original=Groups
+translation=Igrawen
+
+[plugins.graph-view.placeholder-enter-query]
+original=Enter query...
+translation=Sekcem tuttra...
+
+[plugins.graph-view.tooltip-delete-graph]
+original=Delete group
+translation=Kkes agraw
+
+[plugins.graph-view.button-new-group]
+original=New group
+translation=Agraw amaynut
+
+[plugins.graph-view.tooltip-click-to-change-drag-to-reorder]
+original=Click to change color\nDrag to reorder groups
+translation=Sit i ubeddel n yini\nZuɣeṛ i walsi n useggem n yigrawen
+
+[plugins.graph-view.action-timelapse]
+original=Start graph timelapse animation
+translation=Bdu amray n wakud n udlif
+
+[plugins.graph-view.tooltip-start-timelapse-animation]
+original=Start timelapse animation
+translation=Bdu amray n wakud
+
+[plugins.graph-view.button-animate-timelapse]
+original=Animate
+translation=Mru
+
+[plugins.backlinks.name]
+original=Backlinks
+translation=Iseɣwan ikcamen
+
+[plugins.backlinks.desc]
+original=Show links from other files to the current file. Backlinks can be shown in a separate view or at the bottom of the note.
+translation=Sken iseɣwan seg yifuyla nniḍen ɣer ufaylu amiran. Iseɣwan ikcamen zemren ad ttwaskenen deg teskant timziregt neɣ deg wadda n tezmilt.
+
+[plugins.backlinks.action-open]
+original=Open backlinks
+translation=Ldi iseɣwan ikcamen
+
+[plugins.backlinks.action-show]
+original=Show backlinks
+translation=Iseɣwan ikcamen
+
+[plugins.backlinks.action-open-for-current]
+original=Open backlinks for the current note
+translation=Ldi iseɣwan ikcamen i tezmilt tamirant
+
+[plugins.backlinks.action-toggle-backlinks-in-document]
+original=Toggle backlinks in document
+translation=Qluqel iseɣwan ikcamen deg yisemli
+
+[plugins.backlinks.menu-opt-backlinks-in-document]
+original=Backlinks in document
+translation=Iseɣwan ikcamen deg yisemli
+
+[plugins.backlinks.label-linked-mentions]
+original=Linked mentions
+translation=Ibdaren yeqqnen
+
+[plugins.backlinks.label-no-backlinks]
+original=No backlinks found.
+translation=Ulac iseɣwan ikcamen i yettwafan
+
+[plugins.backlinks.label-unlinked-mentions]
+original=Unlinked mentions
+translation=Ibdaren ur neqqin ara
+
+[plugins.backlinks.label-show-search]
+original=Show search filter
+translation=Sken tastayt n unadi
+
+[plugins.backlinks.label-link-button-text]
+original=Link
+translation=Aseɣwen
+
+[plugins.backlinks.tab-title]
+original=Backlinks for {{displayText}}
+translation=Iseɣwan ikcamen i {{displayText}}
+
+[plugins.backlinks.label-no-unlinked-mentions]
+original=No unlinked mentions found.
+translation=Ulac ibdaren ur neqqin ara i yettwafan
+
+[plugins.backlinks.ellipsis]
+original=...
+translation=...
+
+[plugins.backlinks.option-backlink-in-document]
+original=Show backlinks at the bottom of notes
+translation=Sken iseɣwan ikcamen deg wadda n tezmiltin
+
+[plugins.backlinks.option-backlink-in-document-desc]
+original=Make backlinks visible in new tabs by default.
+translation=Err iseɣwan ikcamen d wid yettbanen s umezwer deg yiccaren imaynuten.
+
+[plugins.outgoing-links.name]
+original=Outgoing links
+translation=Iseɣwan uffiɣen
+
+[plugins.outgoing-links.desc]
+original=Show outgoing links and detect unlinked mentions of other notes in the current note.
+translation=Sken iseɣwan uffiɣen yerna af-d ibdaren ur neqqin ara n tezmiltin nniḍen deg tezmilt tamirant. 
+
+[plugins.outgoing-links.action-open]
+original=Open outgoing links
+translation=Ldi iseɣwan uffiɣen
+
+[plugins.outgoing-links.action-show]
+original=Show outgoing links
+translation=Sken iseɣwan uffiɣen
+
+[plugins.outgoing-links.action-open-for-current]
+original=Open outgoing links for the current file
+translation=Ldi iseɣwan uffiɣen i ufaylu amiran
+
+[plugins.outgoing-links.tab-title]
+original=Outgoing links from {{displayText}}
+translation=Iseɣwan uffiɣen seg {{displayText}}. 
+
+[plugins.outgoing-links.label-links]
+original=Links
+translation=Iseɣwan. 
+
+[plugins.outgoing-links.label-no-links]
+original=No links found.
+translation=Ulac iseɣwan i yettwafan. 
+
+[plugins.outgoing-links.label-unlinked-mentions]
+original=Unlinked mentions
+translation=Ibdaren ur neqqin ara
+
+[plugins.outgoing-links.tooltip-link-file]
+original=Link this file
+translation=Sɣewn afaylu-a
+
+[plugins.outgoing-links.tooltip-not-created]
+original=Not created yet
+translation=Ur d-yennulfa ara yakan
+
+[plugins.tag-pane.name]
+original=Tags view
+translation=Taskant n tecraḍ
+
+[plugins.tag-pane.short-name]
+original=Tags
+translation=Ticraḍ
+
+[plugins.tag-pane.desc]
+original=Show a list of all tags and their number of occurrences.
+translation=Sken tabdart n wakk ticraḍ akked wemḍan n tikkal i d-ttbanent.
+
+[plugins.tag-pane.action-show]
+original=Show tags
+translation=Sken ticraḍ
+
+[plugins.tag-pane.label-no-tags]
+original=No tags found.
+translation=Ulac ticraḍ i yettwafan. 
+
+[plugins.tag-pane.label-sort-by-name-a-to-z]
+original=Tag name (A to Z)
+translation=Isem n tecṛeṭ (A ar Z)
+
+[plugins.tag-pane.label-sort-by-name-z-to-a]
+original=Tag name (Z to A)
+translation=Isem n tecṛeṭ (Z ar A)
+
+[plugins.tag-pane.label-sort-by-frequency-high-to-low]
+original=Frequency (high to low)
+translation=Asnagar (afellay ar wadday)
+
+[plugins.tag-pane.label-sort-by-frequency-low-to-high]
+original=Frequency (low to high)
+translation=Asnagar (adday ar ufellay)
+
+[plugins.tag-pane.action-show-nested-tags]
+original=Show nested tags
+translation=Sken ticraḍ yettwaseddegriren
+
+[plugins.tag-pane.action-collapse-all]
+original=Collapse all
+translation=Fneẓ akk
+
+[plugins.tag-pane.action-expand-all]
+original=Expand all
+translation=Semɣer akk
+
+[plugins.footnotes-pane.name]
+original=Footnotes view
+translation=Taskant n yiwenniten n uḍar usebter
+
+[plugins.footnotes-pane.short-name]
+original=Footnotes
+translation=Iwenniten n uḍar usebter
+
+[plugins.footnotes-pane.desc]
+original=Show a list of footnotes from the current note.
+translation=Sken tabdart n yiwenniten n uḍar usebter n tezmilt tamirant.
+
+[plugins.footnotes-pane.action-show]
+original=Show footnotes
+translation=Sken iwenniten n uḍar usebter
+
+[plugins.footnotes-pane.label-no-footnotes]
+original=No footnotes found.
+translation=Ulac iwenniten n uḍar usebter i yettwafan.
+
+[plugins.properties.name]
+original=Properties view
+translation=Taskant n yiraten
+
+[plugins.properties.desc]
+original=Show the metadata for your files in the sidebar.
+translation=Sken adfersefka n yifuyla-k·m deg ugalis.
+
+[plugins.properties.name-global]
+original=All properties
+translation=Akk iraten
+
+[plugins.properties.name-local]
+original=File properties
+translation=Iraten n ufaylu
+
+[plugins.properties.tab-title]
+original=File properties for {{displayText}}
+translation=Iraten n ufaylu i {{displayText}}
+
+[plugins.properties.action-show]
+original=Show all properties
+translation=Sken akk iraten
+
+[plugins.properties.action-show-local]
+original=Show file properties
+translation=Sken iraten n ufaylu
+
+[plugins.properties.opt-delete-properties]
+original=Delete property
+translation=Kkes arat
+
+[plugins.properties.opt-delete-properties_plural]
+original=Delete properties
+translation=Kkes iraten
+
+[plugins.properties.opt-automatic]
+original=Automatic
+translation=Awurman
+
+[plugins.properties.opt-automatic-with-type]
+original=Automatic ({{type}})
+translation=Awurman ({{type}})
+
+[plugins.properties.label-no-properties]
+original=No properties found.
+translation=Ulac iraten i yettwafan.
+
+[plugins.properties.label-invalid-properties]
+original=Invalid properties.
+translation=Iraten irmeɣta.
+
+[plugins.properties.label-sort-by-name-a-to-z]
+original=Property name (A to Z)
+translation=Isem n urat (A ar Z)
+
+[plugins.properties.label-sort-by-name-z-to-a]
+original=Property name (Z to A)
+translation=Isem n urat (Z ar A)
+
+[plugins.properties.label-sort-by-frequency-high-to-low]
+original=Frequency (high to low)
+translation=Asnagar (afellay ar wadday)
+
+[plugins.properties.label-sort-by-frequency-low-to-high]
+original=Frequency (low to high)
+translation=Asnagar (adday ar ufellay)
+
+[plugins.properties.msg-merge-properties-warning]
+original=Merge property “{{oldKey}}” with “{{newKey}}”?
+translation=Zdi arat “{{oldKey}}” d “{{newKey}}”? 
+
+[plugins.properties.msg-merge-properties-warning-desc]
+original=In case of conflicts, the values will be merged or the value from “{{oldKey}}” will be used.
+translation=Deg tegnit n wemgirred, azalen ad ttwezdayen neɣ azal n “{{oldKey}}” ad yettuseqdec. 
+
+[plugins.properties.action-collapse-all]
+original=Collapse all
+translation=Fneẓ akk. 
+
+[plugins.properties.action-expand-all]
+original=Expand all
+translation=Semɣer akk. 
+
+[plugins.properties.action-open-local]
+original=Open file properties
+translation=Ldi iraten n ufaylu
+
+[plugins.properties.action-open-daily-note]
+original=Open daily note
+translation=Ldi tazmilt n yal ass
+
+[plugins.page-preview.name]
+original=Page preview
+translation=Azarskan n usebter
+
+[plugins.page-preview.desc]
+original=Hover an internal link to preview its content. In editor mode, press Ctrl/Cmd while hovering.
+translation=Sɛeddi taḥnaccaṭ ɣef useɣwen agensan i wazarskan n ugbur-is. Deg uskar n umaẓrag, sit ɣef Ctrl/Cmd mi ara tsɛeddayeḍ taḥnaccaṭ.
+
+[plugins.page-preview.label-empty-attachment]
+original=“{{linktext}}” could not be found.
+translation=“{{linktext}}” ur yettwafa ara.
+
+[plugins.page-preview.label-empty-note]
+original=“{{linktext}}” is not created yet. Click to create.
+translation=“{{linktext}}” ur yennulfa ara yakan. Sit i wesnulfu.
+
+[plugins.page-preview.label-missing-footote]
+original=Footnote {{id}} not found. Click to create.
+translation=Awennit n uḍar usebter {{id}} ur yettwafa ara. Sit i wesnulfu.
+
+[plugins.page-preview.label-source-editor]
+original=Editing view
+translation=Taskant n teẓrigt 
+
+[plugins.page-preview.label-source-preview]
+original=Reading view
+translation=Taskant n tɣuri 
+
+[plugins.page-preview.label-source-search]
+original=Search, Backlinks, and Outgoing links
+translation=Anadi, Iseɣwan ikcamen, d Yiseɣwan uffiɣen
+
+[plugins.page-preview.label-source-tab-header]
+original=Tab header
+translation=Tasenṭit n yiccer
+
+[plugins.page-preview.label-require-mod]
+original=Require {{key}} to trigger page preview on hover
+translation=Yesra {{key}} i usenḍeḥ n wazarskan n usebter mi ara tesɛeddayeḍ taḥnaccaṭ
+
+[plugins.bookmarks.name]
+original=Bookmarks
+translation=Isɣalen 
+
+[plugins.bookmarks.desc]
+original=Save shortcuts to files, searches, headings, and graphs.
+translation=Sekles inegzumen ɣer yifuyla, inadiyen, tisenṭa, d yidlifen.
+
+[plugins.bookmarks.action-show]
+original=Show bookmarks
+translation=Sken isɣalen
+
+[plugins.bookmarks.action-collapse-all]
+original=Collapse all
+translation=Fneẓ akk 
+
+[plugins.bookmarks.action-new-bookmark]
+original=Bookmark the active tab...
+translation=Err iccer urmid d asɣal...
+
+[plugins.bookmarks.action-new-group]
+original=New group
+translation=Agraw amaynut 
+
+[plugins.bookmarks.action-bookmark]
+original=Bookmark...
+translation=Asɣal... 
+
+[plugins.bookmarks.action-add-bookmark]
+original=Add bookmark
+translation=Rnu asɣal
+
+[plugins.bookmarks.action-edit-bookmark]
+original=Edit bookmark
+translation=Ẓreg asɣal 
+
+[plugins.bookmarks.action-bookmark-block]
+original=Bookmark block under cursor...
+translation=Err iḥder ddaw n tḥnaccaṭ d asɣal...
+
+[plugins.bookmarks.action-bookmark-heading]
+original=Bookmark heading under cursor...
+translation=Err tasenṭit ddaw n tḥnaccaṭ d asɣal...
+
+[plugins.bookmarks.action-bookmark-search]
+original=Bookmark current search...
+translation=Err anadi amiran d asɣal...
+
+[plugins.bookmarks.action-remove-bookmark]
+original=Remove bookmark for the current file
+translation=Kkes asɣal n ufaylu amiran
+
+[plugins.bookmarks.action-bookmark-tab-group]
+original=Bookmark {{count}} tab...
+translation=Err {{count}} yiccer d asɣal...
+
+[plugins.bookmarks.action-bookmark-tab-group_plural]
+original=Bookmark {{count}} tabs...
+translation=Err {{count}} yiccaren d isɣalen...
+
+[plugins.bookmarks.action-bookmark-all-tabs]
+original=Bookmark all tabs...
+translation=Err akk iccaren d isɣalen...
+
+[plugins.bookmarks.action-bookmark-graph]
+original=Bookmark this graph...
+translation=Err adlif-a d asɣal...
+
+[plugins.bookmarks.label-bookmark]
+original=Bookmark
+translation=Asɣal 
+
+[plugins.bookmarks.label-bookmarked]
+original=Bookmarked
+translation=Yettwarra d asɣal
+
+[plugins.bookmarks.label-bookmark-with-count]
+original={{count}} bookmark
+translation={{count}} usɣal
+
+[plugins.bookmarks.label-bookmark-with-count_plural]
+original={{count}} bookmarks
+translation={{count}} yisɣalen
+
+[plugins.bookmarks.label-no-bookmarks]
+original=No bookmarks found
+translation=Ulac isɣalen i yettwafan
+
+[plugins.bookmarks.label-invalid-data]
+original=Failed to load bookmarks.
+translation=Yecceḍ usali n yisɣalen.
+
+[plugins.bookmarks.label-invalid-data-desc]
+original=The data file is corrupted.
+translation=Afaylu n yisefka yexṣer.
+
+[plugins.bookmarks.label-untitled-group]
+original=Untitled group
+translation=Agraw war azwel
+
+[plugins.bookmarks.label-untitled-graph]
+original=Untitled Graph
+translation=Adlif war azwel
+
+[plugins.bookmarks.menu-opt-edit]
+original=Edit...
+translation=Ẓreg...
+
+[plugins.bookmarks.menu-opt-remove]
+original=Remove
+translation=Kkes 
+
+[plugins.bookmarks.menu-opt-rename]
+original=Rename
+translation=Beddel isem 
+
+[plugins.bookmarks.menu-opt-bookmark-block]
+original=Bookmark this block...
+translation=Err iḥder-a d asɣal...
+
+[plugins.bookmarks.menu-opt-bookmark-heading]
+original=Bookmark this heading...
+translation=Err tasenṭit-a d asɣal...
+
+[plugins.bookmarks.msg-no-search-query]
+original=No search query to bookmark.
+translation=Ulac tuttra n unadi ɣer usɣal.
+
+[plugins.bookmarks.option-path]
+original=Path
+translation=Abrid 
+
+[plugins.bookmarks.option-query]
+original=Query
+translation=Tuttra 
+
+[plugins.bookmarks.option-title]
+original=Title
+translation=Azwel 
+
+[plugins.bookmarks.option-group]
+original=Bookmark group
+translation=Agraw n yisɣalen
+
+[plugins.bookmarks.placeholder-bookmark-group]
+original=Bookmarks
+translation=Isɣalen 
+
+[plugins.custom-css.name]
+original=Custom CSS
+translation=CSS Yettusagenen
+
+[plugins.custom-css.desc]
+original=Read and apply “obsidian.css” in the vault folder.
+translation=Ɣeṛ yerna snes “obsidian.css” deg ukaram n weḥraz.
+
+[plugins.custom-css.setting-community-themes]
+original=Community themes
+translation=Isental n umɣiwan 
+
+[plugins.custom-css.msg-fetching-themes]
+original=Fetching community theme data...
+translation=Awi-d isefka n usentel n umɣiwan...
+
+[plugins.custom-css.prompt-filter]
+original=Filter...
+translation=Tastayt... 
+
+[plugins.custom-css.label-dark-theme-only]
+original=Dark themes only
+translation=Isental ibriken kan
+
+[plugins.custom-css.label-light-theme-only]
+original=Light themes only
+translation=Isental iceɛlalen kan
+
+[plugins.custom-css.label-use]
+original=Use this theme
+translation=Seqdec asentel-a
+
+[plugins.custom-css.label-stop-use]
+original=Stop using this theme
+translation=Ḥbes aseqdec n usentel-a
+
+[plugins.custom-css.label-install-and-use]
+original=Install and use
+translation=Sbedd yerna seqdec
+
+[plugins.custom-css.label-update]
+original=Update
+translation=Mucceḍ 
+
+[plugins.custom-css.label-no-readme]
+original=This theme did not provide a README file.
+translation=Asentel-a ur d-yefki ara afaylu README.
+
+[plugins.custom-css.tooltip-remove-theme]
+original=Remove theme
+translation=Kkes asentel
+
+[plugins.custom-css.label-visit-on-github]
+original=Visit on GitHub
+translation=Rzu ɣef GitHub 
+
+[plugins.custom-css.msg-load-error]
+original=Could not load community themes, please check your network.
+translation=Ur yezmir ara ad isali isental n umɣiwan, ttxil-k·m senqed azeṭṭa-inek·inem. 
+
+[plugins.custom-css.msg-now-using-theme]
+original=You're now using {{title}} as your CSS theme.
+translation=Akka tura tseqdaceḍ {{title}} am usentel-ik·im CSS. 
+
+[plugins.custom-css.msg-deleted-theme]
+original=The theme {{title}} has been deleted.
+translation=Asentel {{title}} yettwakkes. 
+
+[plugins.custom-css.msg-updated-theme]
+original=The theme {{title}} has been updated.
+translation=Asentel {{title}} yettwamucceḍ. 
+
+[plugins.custom-css.label-installed]
+original=Installed
+translation=Yettwasbedd 
+
+[plugins.custom-css.label-legacy]
+original=Legacy
+translation=Aqbur
+
+[plugins.custom-css.button-update-all-themes]
+original=Update all
+translation=Mucceḍ akk 
+
+[plugins.custom-css.msg-failed-load-themes]
+original=Failed to load community themes.
+translation=Yecceḍ usali n yisental n umɣiwan. 
+
+[plugins.custom-css.msg-no-updates-found]
+original=No theme updates found.
+translation=Ulac imuccḍen n yisental i yettwafan. 
+
+[plugins.custom-css.msg-updates-found]
+original=Found {{count}} theme to update.
+translation=Yettwafa {{count}} n usentel i umucceḍ. 
+
+[plugins.custom-css.msg-updates-found_plural]
+original=Found {{count}} themes to update.
+translation=Ttwafan {{count}} n isental i umucceḍ. 
+
+[plugins.custom-css.msg-failed-to-install-theme]
+original=Failed to install theme “{{name}}”.
+translation=Yecceḍ usbeddi n usentel “{{name}}”. 
+
+[plugins.custom-css.msg-successfully-installed-theme]
+original=Successfully installed theme “{{name}}”.
+translation=Asbeddi n usentel “{{name}}” yedda akken iwata. 
+
+[plugins.custom-css.msg-installing-theme]
+original=Installing theme “{{name}}”...
+translation=Asbeddi n usentel “{{name}}”... 
+
+[plugins.custom-css.label-search-summary]
+original=Showing {{themeCount}}
+translation=Yeskanay-d {{themeCount}} 
+
+[plugins.custom-css.label-update-available]
+original=Update available
+translation=Lqem yewjed 
+
+[plugins.command-palette.name]
+original=Command palette
+translation=Tafelwit n tludna 
+
+[plugins.command-palette.desc]
+original=Use Cmd/Ctrl+P and begin typing to invoke a command.
+translation=Seqdec Cmd/Ctrl+P yerna bdu tira i usekker n tladna. 
+
+[plugins.command-palette.action-open]
+original=Open command palette
+translation=Ldi tafelwit n tludna 
+
+[plugins.command-palette.instruction-navigate]
+original=to navigate
+translation=i tunigin 
+
+[plugins.command-palette.instruction-use]
+original=to use
+translation=i useqdec 
+
+[plugins.command-palette.instruction-dismiss]
+original=to dismiss
+translation=agi
+
+[plugins.command-palette.label-no-commands]
+original=No commands found.
+translation=Ulac tiludna i yettwafan. 
+
+[plugins.command-palette.prompt-type-command]
+original=Select a command to add...
+translation=Fren taladna ara ternuḍ... 
+
+[plugins.command-palette.label-pinned-commands]
+original=Pinned commands
+translation=Tiludna yettwasbeḍen 
+
+[plugins.markdown-format-importer.name]
+original=Format converter
+translation=Aselkat n umasal 
+
+[plugins.markdown-format-importer.desc]
+original=Convert Markdown from other apps to Obsidian format.
+translation=Selket Markdown seg yisnasen nniḍen ɣer umasal n Obsidian. 
+
+[plugins.markdown-format-importer.action-open]
+original=Open format converter
+translation=Ldi aselkat n umasal 
+
+[plugins.markdown-format-importer.option-roam-tag-fixer]
+original=Roam Research tag fixer
+translation=Amseɣtay n tecraḍ Roam Research 
+
+[plugins.markdown-format-importer.option-roam-tag-fixer-description]
+original=Converts “#tag” and “#[[tag]]” to “[[tag]]”.
+translation=Yesselkat “#tag” d “#[[tag]]” ɣer “[[tag]]”. 
+
+[plugins.markdown-format-importer.option-roam-highlight-fixer]
+original=Roam Research highlight fixer
+translation=Amseɣtay n usebrureq Roam Research 
+
+[plugins.markdown-format-importer.option-roam-highlight-fixer-description]
+original=Converts “^^highlight^^” to “==highlight==”.
+translation=Yesselkat “^^highlight^^” ɣer “==highlight==”. 
+
+[plugins.markdown-format-importer.option-roam-todo-converter]
+original=Roam Research TODO converter
+translation=Aselkat n TODO Roam Research 
+
+[plugins.markdown-format-importer.option-roam-todo-converter-description]
+original=Converts “{{[[TODO]]}}” to “[ ]”.
+translation=Yesselkat “{{[[TODO]]}}” ɣer “[ ]”. 
+
+[plugins.markdown-format-importer.option-bear-highlight-fixer]
+original=Bear highlight fixer
+translation=Amseɣtay n usebrureq Bear 
+
+[plugins.markdown-format-importer.option-bear-highlight-fixer-description]
+original=Converts “::highlight::” to “==highlight==”.
+translation=Yesselkat “::highlight::” ɣer “==highlight==”. 
+
+[plugins.markdown-format-importer.zettelkasten-link-fixer]
+original=Zettelkasten link fixer
+translation=Amseɣtay n yiseɣwan Zettelkasten 
+
+[plugins.markdown-format-importer.zettelkasten-link-fixer-description]
+original=Fixes “[[UID]]” links to full “[[UID File Name]]”.
+translation=Yeseɣtay iseɣwan “[[UID]]” ɣer “[[UID File Name]]” ummid. 
+
+[plugins.markdown-format-importer.zettelkasten-link-beautifier]
+original=Zettelkasten link beautifier
+translation=Amsicebḥan n yiseɣwan Zettelkasten 
+
+[plugins.markdown-format-importer.zettelkasten-link-beautifier-description]
+original=Fixes “[[UID]]” links and also beautify them “[[UID File Name|File Name]]”.
+translation=Yeseɣtay iseɣwan “[[UID]]” yerna yescebḥay-iten “[[UID File Name|File Name]]”. 
+
+[plugins.markdown-format-importer.frontmatter-migration]
+original=Frontmatter migration
+translation=Tunigin n tsenṭit 
+
+[plugins.markdown-format-importer.frontmatter-migration-description]
+original=Migrate frontmatter tags, aliases, and cssclasses to the strict format required by Obsidian v1.9+
+translation=Sinig ticraḍ n tsenṭit, tizaẓluyin, d tiserkam css ɣer umasal aẓayan i yettusran sɣur Obsidian v1.9+ 
+
+[plugins.markdown-format-importer.msg-all-files-warning]
+original=Warning: the converter will convert all the files in your vault, not just the current file.
+translation=Ɣur-k·m: aselkat ad iselket akk ifuyla deg ukaram-ik·im n weḥraz, mačči kan afaylu amiran. 
+
+[plugins.markdown-format-importer.msg-override-files-warning]
+original=Your files will be overwritten. Back up all your files before attempting conversion.
+translation=Ifuyla-k·m ad ttwasemselsin. Xdem aḥraz i wakk ifuyla-k·m uqbel ad tɛerḍeḍ aselket. 
+
+[plugins.markdown-format-importer.label-start-conversion]
+original=Start conversion
+translation=Bdu aselket 
+
+[plugins.markdown-format-importer.label-stop]
+original=Stop
+translation=Ḥbes 
+
+[plugins.markdown-format-importer.label-go-back]
+original=Go back
+translation=Uɣal ɣer deffir 
+
+[plugins.markdown-format-importer.label-done]
+original=Done
+translation=Ifukk 
+
+[plugins.markdown-format-importer.label-processing]
+original=Processing...
+translation=Asefser... 
+
+[plugins.markdown-format-importer.label-cancelling]
+original=Cancelling...
+translation=Asemmet... 
+
+[plugins.markdown-format-importer.label-finished]
+original=Finished!
+translation=Ifukk! 
+
+[plugins.markdown-format-importer.label-processed-files]
+original=Processed files
+translation=Ifuyla yettwasefsren 
+
+[plugins.markdown-format-importer.label-modified-files]
+original=Modified files
+translation=Ifuyla yettwabeddlen 
+
+[plugins.markdown-format-importer.label-total-replacements]
+original=Total replacements
+translation=Akk isemselsiyen 
+
+[plugins.markdown-format-importer.label-failed]
+original=Failed
+translation=Yecceḍ 
+
+[plugins.daily-notes.name]
+original=Daily notes
+translation=Tizmiltin n yal ass 
+
+[plugins.daily-notes.desc]
+original=Create or open today's daily note.
+translation=Snulfu-d neɣ ldi tazmilt n yal ass n wass-a. 
+
+[plugins.daily-notes.short-name]
+original=Today
+translation=Ass-a 
+
+[plugins.daily-notes.action-open]
+original=Open today's daily note
+translation=Ldi tazmilt n yal ass n wass-a
+
+[plugins.daily-notes.action-open-previous]
+original=Open previous daily note
+translation=Ldi tazmilt n yal ass tuzwirt
+
+[plugins.daily-notes.action-open-next]
+original=Open next daily note
+translation=Ldi tazmilt n yal ass tuḍfirt
+
+[plugins.daily-notes.action-insert-text]
+original=Today's daily note
+translation=Tazmilt n yal ass n wass-a
+
+[plugins.daily-notes.action-insert-link]
+original=Insert link into daily note
+translation=Ger aseɣwen ɣer tezmilt n yal ass 
+
+[plugins.daily-notes.msg-fail-format]
+original=Failed to create daily note. “{{format}}” is not a valid format.
+translation=Yecceḍ wesnulfu n tezmilt n yal ass. “{{format}}” mačči d amasal ameɣtu.
+
+[plugins.daily-notes.msg-fail-folder]
+original=Failed to create daily note. Folder “{{folderOption}}” not found.
+translation=Yecceḍ wesnulfu n tezmilt n yal ass. Akaram “{{folderOption}}” ur yettwafa ara.
+
+[plugins.daily-notes.msg-fail-template-file]
+original=Failed to create daily note. Template file “{{template}}” not found.
+translation=Yecceḍ wesnulfu n tezmilt n yal ass. Afaylu n tmudemt “{{template}}” ur yettwafa ara. 
+
+[plugins.daily-notes.msg-no-previous]
+original=There's no daily note before this one.
+translation=Ulac tazmilt n yal ass uqbel ta.
+
+[plugins.daily-notes.msg-no-next]
+original=There's no daily note after this one.
+translation=Ulac tazmilt n yal ass deffir ta.
+
+[plugins.daily-notes.option-date-format]
+original=Date format
+translation=Amasal n uzemz 
+
+[plugins.daily-notes.option-date-format-desc]
+original=Choose how daily note are named in your vault.
+translation=Fren amek ara ttusemmin tezmiltin n yal ass deg ukaram-ik·im n weḥraz.
+
+[plugins.daily-notes.option-custom-date-format]
+original=Custom format
+translation=Amasal yettusagenen 
+
+[plugins.daily-notes.option-custom]
+original=Custom
+translation=Sagen 
+
+[plugins.daily-notes.msg-invalid-date-format]
+original=Invalid date format
+translation=Amasal n uzemz d armeɣtu
+
+[plugins.daily-notes.msg-missing-folder]
+original=Daily note folder not found.
+translation=Akaram n tezmilt n yal ass ur yettwafa ara.
+
+[plugins.daily-notes.label-refer-to-syntax]
+original=For more syntax, refer to 
+translation=I ugar n tseddast, rzu ɣer 
+
+[plugins.daily-notes.label-syntax-link]
+original=format reference
+translation=tamselɣut n umasal 
+
+[plugins.daily-notes.label-syntax-live-preview]
+original=Your current syntax looks like this: 
+translation=Taseddast-ik·im tamirant tettban-d akka:
+
+[plugins.daily-notes.option-new-file-location]
+original=New file location
+translation=Ideg n ufaylu amaynut 
+
+[plugins.daily-notes.option-new-file-location-description]
+original=New daily notes will be placed here.
+translation=Tizmiltin n yal ass timaynutin ad ttwasersent dagi.
+
+[plugins.daily-notes.option-template]
+original=Template file location
+translation=Ideg n ufaylu n tmudemt 
+
+[plugins.daily-notes.option-template-description]
+original=Choose the file to use as a template.
+translation=Fren afaylu ara tseqdceḍ am tmudemt.
+
+[plugins.unique-note-creator.name]
+original=Unique note creator
+translation=Amesnulfu n tezmilt tasuft 
+
+[plugins.unique-note-creator.desc]
+original=Create notes with unique timestamp prefixes, for workflows like zettelkasten or slip box.
+translation=Snulfu-d tizmiltin s yidaten isufen n uzemzakud, i yikalan n umahil am zettelkasten neɣ slip box. 
+
+[plugins.unique-note-creator.short-name]
+original=Unique
+translation=Asuf 
+
+[plugins.unique-note-creator.action-create-note]
+original=Create new unique note
+translation=Snulfu-d tazmilt tasuft tamaynut
+
+[plugins.unique-note-creator.label-quick-action]
+original=New unique note
+translation=Tazmilt tasuft tamaynut
+
+[plugins.unique-note-creator.action-add-link]
+original=Add unique internal link
+translation=Rnu aseɣwen agensan asuf 
+
+[plugins.unique-note-creator.option-new-file-location]
+original=New file location
+translation=Ideg n ufaylu amaynut 
+
+[plugins.unique-note-creator.option-new-file-location-description]
+original=The folder path to create the new unique note in.
+translation=Abrid n ukaram anda ara d-tesnulfuḍ tazmilt tasuft tamaynut. 
+
+[plugins.unique-note-creator.msg-folder-not-found]
+original=Failed to create unique note. Folder “{{folderOption}}” not found.
+translation=Yecceḍ wesnulfu n tezmilt tasuft. Akaram “{{folderOption}}” ur yettwafa ara.
+
+[plugins.unique-note-creator.option-template-file]
+original=Template file location
+translation=Ideg n ufaylu n tmudemt 
+
+[plugins.unique-note-creator.option-template-file-description]
+original=The file path to use as template.
+translation=Abrid n ufaylu ara yettuseqdec am tmudemt.
+
+[plugins.unique-note-creator.option-template-file-placeholder]
+original=Example: folder1/note
+translation=Amedya: akaram1/tazmilt
+
+[plugins.unique-note-creator.option-id-format]
+original=Unique prefix format
+translation=Amasal n udat asuf
+
+[plugins.unique-note-creator.msg-template-file-not-found]
+original=Failed to create unique note. Template file “{{template}}” not found.
+translation=Yecceḍ wesnulfu n tezmilt tasuft. Afaylu n tmudemt “{{template}}” ur yettwafa ara.
+
+[plugins.unique-note-creator.msg-failed-to-generate]
+original=Failed to generate a unique note with the format “{{format}}”
+translation=Yecceḍ wesirew n tezmilt tasuft s umasal “{{format}}”
+
+[plugins.random-note.name]
+original=Random note
+translation=Tazmilt tagacurant 
+
+[plugins.random-note.desc]
+original=Open a random note to rediscover or review.
+translation=Ldi tazmilt tagacurant i wakken ad tt-id-tmuqleḍ neɣ ad tt-tesnekdeḍ.
+
+[plugins.random-note.short-name]
+original=Random
+translation=Agacuran 
+
+[plugins.random-note.action-open]
+original=Open random note
+translation=Ldi tazmilt tagacurant
+
+[plugins.outline.name]
+original=Outline
+translation=Agbur 
+
+[plugins.outline.desc]
+original=Show the table of contents for the current note.
+translation=Sken agbur n tezmilt tamirant. 
+
+[plugins.outline.action-open]
+original=Open outline
+translation=Ldi agbur
+
+[plugins.outline.action-show]
+original=Show outline
+translation=Sken agbur
+
+[plugins.outline.action-open-for-current]
+original=Open outline of the current file
+translation=Ldi agbur n ufaylu amiran
+
+[plugins.outline.tab-title]
+original=Outline of {{displayText}}
+translation=Agbur n {{displayText}}
+
+[plugins.outline.label-no-headings]
+original=No headings found.
+translation=Ulac tisenṭa i yettwafan.
+
+[plugins.outline.label-follow-cursor]
+original=Auto-scroll to current section
+translation=Adrurem awurman ɣer tgezmi tamirant 
+
+[plugins.word-count.name]
+original=Word count
+translation=Amḍan n wawalen 
+
+[plugins.word-count.desc]
+original=Show word count in the status bar.
+translation=Sken amḍan n wawalen deg tfeggagt n waddad.
+
+[plugins.slides.name]
+original=Slides
+translation=Tigriwin 
+
+[plugins.slides.desc]
+original=Create a presentation by using “---” to separate slides.
+translation=Snulfu-d tihawt s useqdec n “---” i ufeṛṛeq n tigriwin. 
+
+[plugins.slides.action-start]
+original=Start presentation
+translation=Bdu tihawt 
+
+[plugins.audio-recorder.name]
+original=Audio recorder
+translation=Amaklas n yimesli 
+
+[plugins.audio-recorder.desc]
+original=Record audio notes and save them as attachments.
+translation=Kles tizmiltin n yimesli yerna ḥrez-itent d imeddayen.
+
+[plugins.audio-recorder.action-start]
+original=Start recording audio
+translation=Bdu aklas n yimesli
+
+[plugins.audio-recorder.action-stop]
+original=Stop recording audio
+translation=Ḥbes aklas n yimesli
+
+[plugins.audio-recorder.action-toggle]
+original=Start/stop recording
+translation=Bdu/ḥbes aklas
+
+[plugins.audio-recorder.msg-access-denied]
+original=Microphone access was denied, please enable it from the preference pane.
+translation=Adduf ɣer umikṛufun yettwagi, ttxil-k·m sermed-it seg ugalis n yismenyifen.
+
+[plugins.audio-recorder.msg-pending-grant]
+original=Please grant microphone permission to start recording.
+translation=Ttxil-k·m mudd asireg n umikṛufun i wakken ad tebduḍ aklas.
+
+[plugins.audio-recorder.msg-no-microphone]
+original=No microphone is connected.
+translation=Ulac amikṛufun yeqqnen.
+
+[plugins.open-with-default-app.name]
+original=Open in default app
+translation=Ldi deg usnas amezwer
+
+[plugins.open-with-default-app.desc]
+original=Add a button to open the current file in its default app.
+translation=Rnu taqeffalt i welday n ufaylu amiran deg usnas-is amezwer.
+
+[plugins.open-with-default-app.action-open-file]
+original=Open in default app
+translation=Ldi deg usnas amezwer
+
+[plugins.open-with-default-app.action-open-file-mobile]
+original=Share
+translation=Bḍu
+
+[plugins.open-with-default-app.action-show-in-folder]
+original=Show in system explorer
+translation=Sken deg unaram n unagraw
+
+[plugins.open-with-default-app.action-show-in-folder-mac]
+original=Reveal in Finder
+translation=Sken deg Finder
+
+[plugins.templates.name]
+original=Templates
+translation=Timudmiwin
+
+[plugins.templates.desc]
+original=Insert template content from a folder of template files.
+translation=Ger agbur n tmudemt seg ukaram n yifuyla n tmudmiwin.
+
+[plugins.templates.action-insert]
+original=Insert template
+translation=Ger tamudemt
+
+[plugins.templates.action-insert-current-date]
+original=Insert current date
+translation=Ger azemz amiran
+
+[plugins.templates.action-insert-current-time]
+original=Insert current time
+translation=Ger akud amiran
+
+[plugins.templates.option-template-folder-location]
+original=Template folder location
+translation=Ideg n ukaram n tmudmiwin
+
+[plugins.templates.option-template-folder-location-description]
+original=Files in this folder will be available as templates.
+translation=Ifuyla deg ukaram-a ad stufun am tmudmiwin.
+
+[plugins.templates.option-template-date-format]
+original=Date format
+translation=Amasal n uzemz
+
+[plugins.templates.option-template-date-format-description]
+original={{date}} in the template file will be replaced with this value.
+translation={{date}} deg ufaylu n tmudemt ad yettwasemselsi s wazal-a.
+
+[plugins.templates.option-template-date-format-description2]
+original=You can also use {{date:YYYY-MM-DD}} to override the format once.
+translation=Tzemreḍ daɣen ad tseqdceḍ {{date:YYYY-MM-DD}} i wakken ad tsemselsiḍ amasal yiwet n tikkelt.
+
+[plugins.templates.option-template-time-format]
+original=Time format
+translation=Amasal n wakud
+
+[plugins.templates.option-template-time-format-description]
+original={{time}} in the template file will be replaced with this value.
+translation={{time}} deg ufaylu n tmudemt ad yettwasemselsi s wazal-a.
+
+[plugins.templates.option-template-time-format-description2]
+original=You can also use {{time:HH:mm}} to override the format once.
+translation=Tzemreḍ daɣen ad tseqdceḍ {{time:HH:mm}} i wakken ad tsemselsiḍ amasal yiwet n tikkelt.
+
+[plugins.templates.instruction-navigate]
+original=to navigate
+translation=i tunigin
+
+[plugins.templates.instruction-insert]
+original=to insert template
+translation=i tguri n tmudemt
+
+[plugins.templates.instruction-dismiss]
+original=to dismiss
+translation=i tugin
+
+[plugins.templates.msg-no-templates-found]
+original=No templates found
+translation=Ulac timudmiwin i yettwafan
+
+[plugins.templates.msg-fail-invalid-folder]
+original=Failed to list templates. Template folder is invalid.
+translation=Yecceḍ uskan n tmudmiwin. Akaram n tmudmiwin ur yeɣbil ara.
+
+[plugins.templates.msg-fail-folder-not-found]
+original=Failed to list templates. Folder “{{folderOption}}” not found.
+translation=Yecceḍ uskan n tmudmiwin. Akaram “{{folderOption}}” ur yettwafa ara.
+
+[plugins.templates.msg-fail-invalid-template-properties]
+original=Unable to insert template, the properties in the template file could not be read.
+translation=Ur yezmir ara ad iger tamudemt, iraten deg ufaylu n tmudemt ur gzin ara i tɣuri.
+
+[plugins.templates.msg-no-folder-set]
+original=Failed to list templates. No template folder configured.
+translation=Yecceḍ uskan n tmudmiwin. Ulac akaram n tmudmiwin yettwaswlen.
+
+[plugins.templates.prompt-type-template]
+original=Type name of a template...
+translation=Aru isem n tmudemt...
+
+[plugins.translucency.name]
+original=Translucent window
+translation=Asfaylu amseɣseɣ
+
+[plugins.translucency.desc]
+original=Turn on translucency effect to enhance a sense of depth. Best used with dark mode. Not supported on Linux.
+translation=Rmed asemdu n timseɣseɣt i wesnerni n uḥulfu n walqay. Yif-it useqdec-is d waskar ubrik. Ur yettusefrak ara ɣef Linux.
+
+[plugins.slash-command.name]
+original=Slash commands
+translation=Tiludna Slash (/)
+
+[plugins.slash-command.desc]
+original=Trigger commands in the editor by using the forward slash key.
+translation=Sendeḥ tiludna deg umaẓrag s useqdec n tqeffalt n ujeṛṛid uknan.
+
+[plugins.editor-status.name]
+original=Show editing mode in status bar
+translation=Sken askar n teẓrigt deg tfeggagt n waddad
+
+[plugins.editor-status.desc]
+original=Show the editing mode toggle in the status bar.
+translation=Sken aqluqel n waskar n teẓrigt deg tfeggagt n waddad.
+
+[plugins.editor-status.read]
+original=Reading
+translation=Taɣuri
+
+[plugins.editor-status.edit-source]
+original=Source mode
+translation=Askar n uɣbalu
+
+[plugins.editor-status.edit-live-preview]
+original=Live Preview
+translation=Azarskan s wudem usrid
+
+[plugins.publish.name]
+original=Publish
+translation=Tasuffeɣt
+
+[plugins.publish.desc]
+original=Host your notes online as a website, wiki or documentation.
+translation=Sers tizmiltin-ik·im n srid am usmel Web, wiki neɣ isemliyen.
+
+[plugins.publish.action-publish-changes]
+original=Publish changes...
+translation=Suffeɣ-d ibeddilen...
+
+[plugins.publish.action-publish-file]
+original=Publish current file
+translation=Suffeɣ-d afaylu amiran
+
+[plugins.publish.label-no-internet-access]
+original=You need access to the internet to publish changes.
+translation=Teḥwaǧeḍ adduf ɣer Internet i wakken ad d-tsuffɣeḍ ibeddilen.
+
+[plugins.publish.label-publish-service-description]
+original=Obsidian Publish is an add-on paid service that lets you publish your notes online directly from Obsidian.
+translation=Tasuffeɣt Obsidian d ameẓlu yettwaxelṣen i k·em-yettaken tagnit ad d-tsuffɣeḍ tizmiltin-ik·im srid seg Obsidian.
+
+[plugins.publish.label-please-login]
+original=To start publishing, please log in or create a new Obsidian account.
+translation=I wakken ad tebduḍ tasuffeɣt, ttxil-k·m kcem neɣ rnu amiḍan amaynut Obsidian.
+
+[plugins.publish.label-no-publish-subscription]
+original=You do not have an Obsidian Publish subscription yet.
+translation=Ur tesɛiḍ ara yakan amtawa n Tesuffeɣt Obsidian.
+
+[plugins.publish.button-purchase]
+original=Purchase
+translation=Aɣ
+
+[plugins.publish.label-manage-sites]
+original=Manage sites
+translation=Sefrek ismal
+
+[plugins.publish.label-no-sites]
+original=You don't have any sites.
+translation=Ur tesɛiḍ ula d yiwen usmel.
+
+[plugins.publish.button-choose]
+original=Choose
+translation=Fren
+
+[plugins.publish.tooltip-edit-site-id]
+original=Edit site ID
+translation=Ẓreg asulay n usmel
+
+[plugins.publish.tooltip-delete-site]
+original=Delete site
+translation=Kkes asmel
+
+[plugins.publish.label-delete-site-confirmation]
+original=Are you sure you want to delete this site?
+translation=Tebɣiḍ s tidet ad tekkseḍ asmel-a?
+
+[plugins.publish.label-delete-site-details]
+original=This will immediately and permanently delete your site.
+translation=Aya ad yekkes asmel-ik·im din din yerna s wudem imezgi.
+
+[plugins.publish.label-confirm-delete-site]
+original=Confirm delete site “{{site}}”
+translation=Sentem tukksa n usmel “{{site}}”
+
+[plugins.publish.option-site-id]
+original=Site ID
+translation=Asulay n usmel
+
+[plugins.publish.option-site-id-description]
+original=Your site will be at https://publish.obsidian.md/{site id}. You can change this later. Only lower case letters, numbers, and dashes are allowed.
+translation=Asmel-ik·im ad yili deg https://publish.obsidian.md/{site id}. Tzemreḍ ad t-tbeddleḍ sakin. Isekkilen imeẓyanen, imḍanen, d yijeṛṛiden kan i yettwasirgen.
+
+[plugins.publish.option-site-id-placeholder]
+original=Pick a site ID
+translation=Fren asulay n usmel
+
+[plugins.publish.button-create]
+original=Create
+translation=Snulfu-d
+
+[plugins.publish.msg-invalid-site-id]
+original=Site ID can only contain lowercase letters, numbers, and dashes.
+translation=Asulay n usmel yezmer ad yesɛu kan isekkilen imeẓyanen, imḍanen, d yijeṛṛiden.
+
+[plugins.publish.msg-site-id-in-use]
+original=This site ID is in use, please try another one.
+translation=Asulay-a n usmel yettuseqdac, ttxil-k·m ɛreḍ wayeḍ.
+
+[plugins.publish.msg-create-site-issue]
+original=There was an issue when creating your site.
+translation=Yella-d wugur deg wesnulfu n usmel-ik·im.
+
+[plugins.publish.label-site-options]
+original=Site options
+translation=Tixtiṛiyin n usmel
+
+[plugins.publish.option-site-general]
+original=General
+translation=Amatu
+
+[plugins.publish.option-site-components]
+original=Components
+translation=Isegran
+
+[plugins.publish.option-site-appearance]
+original=Appearance
+translation=Timeẓri
+
+[plugins.publish.option-site-reading-experience]
+original=Reading experience
+translation=Tirmit n tɣuri
+
+[plugins.publish.option-site-misc]
+original=Other site settings
+translation=Iɣewwaṛen nniḍen n usmel
+
+[plugins.publish.option-site-name]
+original=Site name
+translation=Isem n usmel
+
+[plugins.publish.option-site-name-description]
+original=Name of your published site. It will show up in the page title of your site.
+translation=Isem n usmel-ik·im yettwasuffɣen. Ad d-yeban deg uzwel n usebter n usmel-ik·im.
+
+[plugins.publish.option-site-name-placeholder]
+original=Name of your site
+translation=Isem n usmel-ik·im
+
+[plugins.publish.option-home-page-file]
+original=Homepage file
+translation=Afaylu n usebter agejdan
+
+[plugins.publish.option-home-page-file-description]
+original=The first page the user sees when landing on your published site
+translation=Asebter amezwaru ara yewali useqdac mi ara d-yekcem ɣer usmel-ik·im yettwasuffɣen.
+
+[plugins.publish.option-home-page-file-placeholder]
+original=Pick a published file
+translation=Fren afaylu yettwasuffɣen
+
+[plugins.publish.option-logo]
+original=Logo
+translation=Alugu
+
+[plugins.publish.option-logo-description]
+original=Pick an image file as your site logo.
+translation=Fren afaylu n tugna am ulugo n usmel-ik·im.
+
+[plugins.publish.option-logo-placeholder]
+original=Any uploaded image in your vault...
+translation=Yal tugna yettwasulin deg ukaram-ik·im n weḥraz...
+
+[plugins.publish.option-site-collaboration]
+original=Site collaboration
+translation=Amɛawan deg usmel
+
+[plugins.publish.option-site-collaboration-desc]
+original=Manage collaborators for this site.
+translation=Sefrek imɛawnen i usmel-a.
+
+[plugins.publish.option-customize-navigation]
+original=Customize navigation
+translation=Sagen tunigin
+
+[plugins.publish.option-customize-navigation-desc]
+original=Override the order of navigation items and hide pages or folders from showing.
+translation=Semselsi amizzwer n yiferdisen n tunigin yerna ffer isebtar neɣ ikaramen i wakken ur d-ttbanen ara.
+
+[plugins.publish.option-navigation-order]
+original=Navigation item display order
+translation=Amizzwer n ubeqqeḍ n yiferdisen n tunigin
+
+[plugins.publish.option-hide-items-in-navigation]
+original=Hide pages or folders from navigation
+translation=Ffer isebtar neɣ ikaramen seg tunigin
+
+[plugins.publish.option-hide-items-in-navigation-desc]
+original=Right click and select “Hide” to prevent specific pages from appearing in the site navigation. The pages will still be accessible via links or accessing the URL directly.
+translation=Sit s uyeffus yerna fren "Ffer" i wakken ad tsewḥeleḍ isebtar uzzigen ur d-ttbanen ara deg tunigin n usmel. Isebtar ad qimen stufan s yiseɣwan neɣ s unekcum ɣer URL srid.
+
+[plugins.publish.option-show-hidden-items]
+original=Show hidden
+translation=Sken wid yeffren
+
+[plugins.publish.button-customize-sidebar]
+original=Manage
+translation=Sefrek
+
+[plugins.publish.label-navigation-modal-title]
+original=Navigation
+translation=Tunigin
+
+[plugins.publish.label-navigation-modal-desc]
+original=Drag and drop to customize the order in which navigation items appear on your Publish site.
+translation=Zuɣeṛ yerna sers i wakken ad tsageneḍ amizzwer s wayes ara d-banen yiferdisen n tunigin deg usmel-ik·im n Tesuffeɣt.
+
+[plugins.publish.option-hide-in-navigation]
+original=Hide in navigation
+translation=Ffer deg tunigin
+
+[plugins.publish.button-manage-collaborators]
+original=Manage
+translation=Sefrek
+
+[plugins.publish.option-theme]
+original=Theme
+translation=Asentel
+
+[plugins.publish.option-theme-description]
+original=Choose default color scheme for your site.
+translation=Fren azenziɣ n yini amezwer i usmel-ik·im.
+
+[plugins.publish.option-theme-system]
+original=Adapt to system
+translation=Sezg ɣer unagraw
+
+[plugins.publish.option-show-theme-toggle]
+original=Light/dark toggle
+translation=Aqluqel aceɛlal/ubrik
+
+[plugins.publish.option-show-theme-toggle-description]
+original=Let visitors toggle between light and dark theme on their own.
+translation=Eǧǧ inebgawen ad qluqlen gar usentel aceɛlal d ubrik s yiman-nsen.
+
+[plugins.publish.option-show-navigation]
+original=Show navigation
+translation=Sken tunigin
+
+[plugins.publish.option-show-navigation-description]
+original=Display a list of all published pages on the left side of your published site.
+translation=Sken tabdart n wakk isebtar yettwasuffɣen ɣef tama tazelmaṭ n usmel-ik·im yettwasuffɣen.
+
+[plugins.publish.option-show-search]
+original=Show search bar
+translation=Sken afeggag n unadi
+
+[plugins.publish.option-show-search-description]
+original=Display a search bar that lets the visitors search pages, aliases, and headings on your site.
+translation=Sken afeggag n unadi i yettaken tagnit i yinebgawen ad nadin isebtar, tizaẓluyin, d tsenṭa deg usmel-ik·im.
+
+[plugins.publish.option-show-graph]
+original=Show graph view
+translation=Sken taskant n udlif
+
+[plugins.publish.option-show-graph-description]
+original=Display a small local graph on each page.
+translation=Sken adlif adigan ameẓyan deg yal asebter.
+
+[plugins.publish.option-show-outline]
+original=Show table of contents
+translation=Sken-d tafelwit n igburen
+
+[plugins.publish.option-show-outline-description]
+original=Display the outline of headings on each page.
+translation=Sken agbur n tsenṭa deg yal asebter.
+
+[plugins.publish.option-show-backlinks]
+original=Show backlinks
+translation=Sken iseɣwan ikcamen
+
+[plugins.publish.option-show-backlinks-description]
+original=Show backlink section at the end of each page.
+translation=Sken tgezmi n yiseɣwan ikcamen deg taggara n yal asebter.
+
+[plugins.publish.option-sliding-window-mode]
+original=Stack pages
+translation=Semnenni isebtar
+
+[plugins.publish.option-sliding-window-mode-description]
+original=Links will open next to the current page in the same window. Scroll horizontally to see stacked pages.
+translation=Iseɣwan ad ldin zdat n usebter amiran deg yiwen n usfaylu. Drurem s wudem aglawan i wakken ad twaliḍ isebtar yettwasemnennayen.
+
+[plugins.publish.option-hover-preview-file]
+original=Show hover preview
+translation=Sken azarskan s usɛeddi n tḥnaccaṭ
+
+[plugins.publish.option-hover-preview-file-description]
+original=Display page preview when hovering links.
+translation=Sken azarskan n usebter mi ara tsɛeddayeḍ taḥnaccaṭ ɣef yiseɣwan.
+
+[plugins.publish.option-hide-title]
+original=Hide page title
+translation=Ffer azwel n usebter
+
+[plugins.publish.option-hide-title-description]
+original=Hide the page title heading. Useful when you have your own headings at the beginning of each page.
+translation=Ffer tasenṭit n uzwel n usebter. Yenfaɛ mi ara tesɛuḍ tisenṭa-k·m yakan deg tazwara n yal asebter.
+
+[plugins.publish.option-readable-line-length]
+original=Readable line length
+translation=Teɣzi n yizirig yettwaɣren
+
+[plugins.publish.option-readable-line-length-description]
+original=Limit maximum line length. Fits less content on the screen, but makes long paragraphs more readable.
+translation=Eg talast i teɣzi tafellayt n yizirig. Drus n ugbur i d-yeffɣen ɣef ugdil, maca yettarra tiseddaṛin tiɣezfanin ad ttwaɣrent xir.
+
+[plugins.publish.option-site-password]
+original=Passwords
+translation=Awalen n uɛeddi
+
+[plugins.publish.option-site-password-description]
+original=Restrict access to your site with passwords.
+translation=Qqen adduf ɣer usmel-ik·im s wawalen n uɛeddi.
+
+[plugins.publish.option-google-analytics]
+original=Google Analytics tracking code
+translation=Tangalt n uḍfaṛ n Google Analytics
+
+[plugins.publish.option-google-analytics-description]
+original=Configure Google Analytics for your site. Only available for visitors from your custom domain URL. Please check with your local laws and regulations first.
+translation=Swel Google Analytics i usmel-ik·im. Yewjed kan i yinebgawen seg URL n taɣult-ik·im yettusagenen. Ttxil-k·m senqed isuḍaf-ik d yilugan idiganen uqbel.
+
+[plugins.publish.button-manage-passwords]
+original=Manage
+translation=Sefrek
+
+[plugins.publish.button-save-site-settings]
+original=Save site settings
+translation=Sekles iɣewwaṛen n usmel
+
+[plugins.publish.msg-updated-options]
+original=Updated options for your site.
+translation=Tixtiṛiyin ttumuccḍent i usmel-ik·im.
+
+[plugins.publish.button-go-back]
+original=Back
+translation=Uɣal ɣer deffir 
+
+[plugins.publish.label-publishing-to]
+original=Publishing to
+translation=Tasuffeɣt ɣer
+
+[plugins.publish.tooltip-switch-site]
+original=Switch site
+translation=Beddel asmel 
+
+[plugins.publish.button-add-linked]
+original=Add linked
+translation=Rnu wid yeqqnen
+
+[plugins.publish.tooltip-add-linked]
+original=Add all files that are linked by currently selected items
+translation=Rnu akk ifuyla i yeqqnen sɣur yiferdisen yettwafrenen tura
+
+[plugins.publish.msg-added-linked-files]
+original={{count}} linked file has been added.
+translation=Yettwarna {{count}} ufaylu yeqqnen.
+
+[plugins.publish.msg-added-linked-files_plural]
+original={{count}} linked files have been added.
+translation=Ttwarnan {{count}} n yifuyla yeqqnen.
+
+[plugins.publish.tooltip-open-site-options]
+original=Change site options
+translation=Beddel tixtiṛiyin n usmel 
+
+[plugins.publish.label-no-changes-detected]
+original=No changes were detected.
+translation=Ulac ibeddilen i yettwafan.
+
+[plugins.publish.label-changed-files-to-be-published]
+original=Changed
+translation=Yettwabeddel 
+
+[plugins.publish.label-unchanged-files-already-published]
+original=Unchanged (select to unpublish)
+translation=Ur yettwabeddel ara (fren i wakken ad tekkseḍ tasuffeɣt) 
+
+[plugins.publish.label-file-selected]
+original= selected
+translation= yettwafren 
+
+[plugins.publish.button-select-all-files]
+original=Select all
+translation=Fren akk 
+
+[plugins.publish.label-custom-navigation-title]
+original=Navigation items
+translation=Iferdisen n tunigin 
+
+[plugins.publish.button-deselect-all-files]
+original=Deselect all
+translation=Kkes akk tafrayt 
+
+[plugins.publish.label-new-files-to-be-published]
+original=New
+translation=Amaynut 
+
+[plugins.publish.button-publish]
+original=Publish
+translation=Suffeɣ-d
+
+[plugins.publish.msg-no-permission-to-publish-to-site]
+original=You do not have permissions to publish to the current site.
+translation=Ur tesɛiḍ ara isirigen i wakken ad d-tsuffɣeḍ ɣer usmel amiran. 
+
+[plugins.publish.msg-select-at-least-one-file]
+original=Please select at least one file.
+translation=Ttxil-k·m fren a ttaqal yiwen ufaylu. 
+
+[plugins.publish.label-upload-changes]
+original=Upload changes
+translation=Sali ibeddilen 
+
+[plugins.publish.button-done]
+original=Done
+translation=Ifukk 
+
+[plugins.publish.button-stop]
+original=Stop
+translation=Ḥbes 
+
+[plugins.publish.label-status-uploading]
+original=Uploading
+translation=Asali 
+
+[plugins.publish.label-status-to-publish]
+original=To publish
+translation=I tsuffeɣt
+
+[plugins.publish.label-status-to-delete]
+original=To delete
+translation=I tukksa 
+
+[plugins.publish.label-status-published]
+original=Published
+translation=Yettwasuffeɣ
+
+[plugins.publish.label-status-deleted]
+original=Deleted
+translation=Yettwakkes 
+
+[plugins.publish.label-status-failed]
+original=Failed
+translation=Yecceḍ 
+
+[plugins.publish.label-status-cancelled]
+original=Cancelled
+translation=Yettwasemmet 
+
+[plugins.publish.button-change]
+original=Change
+translation=Beddel 
+
+[plugins.publish.label-clear-cache]
+original=It takes up to a few minutes for the changes to show up on your site. If you do not see your latest changes, try clearing the cache in your browser.
+translation=Tettaṭṭaf kra n tsedatin i wakken ibeddilen ad d-banen deg usmel-ik·im. Ma yella ur twalaḍ ara ibeddilen-ik ineggura, ɛreḍ ad tesfeḍeḍ tazarkatut deg yiminig-ik·im. 
+
+[plugins.publish.label-visit-site]
+original=You can visit your site here: 
+translation=Tzemreḍ ad terzuḍ ɣef usmel-ik·im dagi: 
+
+[plugins.publish.msg-something-went-wrong]
+original=Something went wrong.
+translation=Yella wugur i d-yeḍran. 
+
+[plugins.publish.msg-network-error]
+original=A network error occurred.
+translation=Temlal-d tuccḍa n uzeṭṭa. 
+
+[plugins.publish.label-manage-passwords]
+original=Manage passwords
+translation=Sefrek awalen n uɛeddi 
+
+[plugins.publish.label-add-password]
+original=Add password
+translation=Rnu awal n uɛeddi 
+
+[plugins.publish.action-new-password]
+original=New password
+translation=Awal n uɛeddi amaynut 
+
+[plugins.publish.label-no-password]
+original=Your site currently does not have any passwords. Anyone can visit it.
+translation=Asmel-ik·im akka tura ur yesɛi ula d yiwen wawal n uɛeddi. Yal amdan yezmer ad t-yerzu ɣur-s.
+
+[plugins.publish.label-have-password]
+original=Your site is password protected. If you have multiple passwords, visitors can access your site by entering any of them.
+translation=Asmel-ik·im yettwammesten s wawal n uɛeddi. Ma yella tesɛiḍ aṭas n wawalen n uɛeddi, inebgawen zemren ad kecmen ɣer usmel-ik·im ma sekcmen yiwen seg-sen. 
+
+[plugins.publish.option-password-name]
+original=Password
+translation=Awal n uɛeddi 
+
+[plugins.publish.option-password-desc]
+original=A hash of your password will be stored securely. Once the password is set, it cannot be revealed in plaintext.
+translation=Ageddeḥ n wawal-ik·im n uɛeddi ad yettwaḥrez s tɣellist. Akken kan ara yettwasbedd wawal n uɛeddi, ur yezmir ara ad d-yettban d aḍris aḥerfi.
+
+[plugins.publish.option-password-placeholder]
+original=Your password
+translation=Awal-ik·im n uɛeddi
+
+[plugins.publish.option-nickname-name]
+original=Nickname (optional)
+translation=Tazaẓlut (axetṛan)
+
+[plugins.publish.option-nickname-desc]
+original=Set a nickname to remind yourself what or who the password is for.
+translation=Sbadu tazaẓlut i wakken ad tesmektayeḍ iman-ik·im ɣef wacu neɣ i wumi yettwaxdem wawal n uɛeddi.
+
+[plugins.publish.action-add-password]
+original=Add this password
+translation=Rnu awal-a n uɛeddi
+
+[plugins.publish.label-untitled-password]
+original=Untitled password
+translation=Awal n uɛeddi war azwel
+
+[plugins.publish.label-password-created-time]
+original=Created {{time}}
+translation=Yennulfa-d deg {{time}}
+
+[plugins.publish.msg-added-new-password]
+original=Added new password.
+translation=Yettwarna wawal n uɛeddi amaynut.
+
+[plugins.publish.option-custom-domain]
+original=Custom domain
+translation=Taɣult yettusagenen
+
+[plugins.publish.option-custom-domain-desc]
+original=Use your own domain rather than the https://publish.obsidian.md/{site id} URL.
+translation=Seqdec taɣult-ik·im deg umkan n URL https://publish.obsidian.md/{site id}.
+
+[plugins.publish.option-noindex]
+original=Disallow search engine indexing
+translation=Agi asmiter n yimsaddayen n unadi
+
+[plugins.publish.option-noindex-desc]
+original=Prevent search engines from indexing your site.
+translation=Sewḥel imsaddayen n unadi seg usmiter n usmel-ik·im.
+
+[plugins.publish.button-configure]
+original=Configure
+translation=Swel
+
+[plugins.publish.label-configure-custom-domain]
+original=Configure custom domain
+translation=Swel taɣult yettusagenen
+
+[plugins.publish.option-custom-url-name]
+original=Custom URL
+translation=URL yettusagenen
+
+[plugins.publish.option-custom-url-desc]
+original=Enter the URL of your custom site, do not include “www.”
+translation=Sekcem URL n usmel-ik·im yettusagenen, ur sedduy ara “www.”
+
+[plugins.publish.option-custom-url-redirect]
+original=Redirect to your custom domain
+translation=Ales awelleh ɣer taɣult-ik·im yettusagenen
+
+[plugins.publish.option-custom-url-redirect-desc]
+original=Redirect visitors on publish.obsidian.md/id to your custom domain.
+translation=Ales awelleh n yinebgawen ɣef publish.obsidian.md/id ɣer taɣult-ik·im yettusagenen.
+
+[plugins.publish.button-update-custom-domain]
+original=Update domain setting
+translation=Mucceḍ tawila n taɣult
+
+[plugins.publish.label-custom-domain-instructions]
+original=Please refer to our {{link}} on our help site for more information.
+translation=Ttxil-k·m rzu ɣer {{link}} deg usmel-nneɣ n tallalt i wugar n telɣut.
+
+[plugins.publish.label-custom-domain-link-name]
+original=custom domain setup guide
+translation=amnar n usbeddi n taɣult yettusagenen
+
+[plugins.publish.label-site-usage]
+original=You're using {{site}} out of your {{limit}}.
+translation=Tseqdaceḍ {{site}} seg talast-ik·im n {{limit}}.
+
+[plugins.publish.button-add-more-sites]
+original=Add more sites
+translation=Rnu ugar n yismalen
+
+[plugins.publish.label-no-sites-bought]
+original=You haven't bought any sites.
+translation=Ur tuɣeḍ ula d yiwen usmel.
+
+[plugins.publish.button-get-site]
+original=Get a site
+translation=Awi-d asmel
+
+[plugins.publish.label-manage-sharing]
+original=Manage sharing for “{{name}}”
+translation=Sefrek beṭṭu i “{{name}}”
+
+[plugins.publish.label-sharing-with-users]
+original=This site is currently shared with the following people:
+translation=Asmel-a yettwabḍa tura akked yemdanen-a:
+
+[plugins.publish.label-not-sharing]
+original=This site is not currently shared with anyone.
+translation=Asmel-a ur yettwabḍa d ula d yiwen tura.
+
+[plugins.publish.label-invite-pending]
+original=Pending
+translation=Yettraǧu
+
+[plugins.publish.tooltip-remove-user]
+original=Remove user
+translation=Kkes aseqdac
+
+[plugins.publish.option-invite-user]
+original=Invite user
+translation=Ɛreḍ aseqdac
+
+[plugins.publish.placeholder-invite-user]
+original=Enter their email...
+translation=Sekcem imayl-nsen...
+
+[plugins.publish.error-email-must-be-valid]
+original=Please enter a valid email to invite someone.
+translation=Ttxil-k·m sekcem imayl ameɣtu i wakken ad teɛerḍeḍ amdan.
+
+[plugins.publish.msg-enable-publish-plugin]
+original=Please enable the Publish core plugin in Settings -> Core plugins to view sites.
+translation=Ttxil-k·m sermed azegrir agejdan Tasuffeɣt deg Iɣewwaren -> Izegrar igejdanen i wakken ad twaliḍ ismal.
+
+[plugins.publish.label-your-sites]
+original=Your sites
+translation=Ismal-ik·im
+
+[plugins.publish.label-sites-shared-with-you]
+original=Sites shared with you
+translation=Ismal i d-yettwabḍan yid-k·m
+
+[plugins.publish.tooltip-leave-site-sharing]
+original=Stop collaborating on this site
+translation=Ḥbes amɛawan deg usmel-a
+
+[plugins.publish.label-leave-site-confirmation]
+original=Confirm stop site collaboration
+translation=Sentem aḥbas n umɛawan n usmel
+
+[plugins.publish.label-leave-site-confirmation-details]
+original=This will remove this site from the list of sites shared with you. This action cannot be reverted.
+translation=Aya ad yekkes asmel-a seg tebdart n yismalen i d-yettwabḍan yid-k·m. Tigawt-a ur tezmir ara ad tettwasemmet.
+
+[plugins.publish.label-leave-site-confirmation-details-2]
+original=Please contact the owner of the site if you wish to collaborate on this site again.
+translation=Ttxil-k·m nermes d bab n usmel ma tebɣiḍ ad tmɛawaneḍ deg usmel-a tikkelt nniḍen.
+
+[plugins.publish.button-leave]
+original=Leave
+translation=Eǧǧ
+
+[plugins.publish.label-compare-with-live]
+original=Compare with live version
+translation=Snemhel d lqem amiran
+
+[plugins.publish.button-use-live-version]
+original=Use live version
+translation=Seqdec lqem amiran
+
+[plugins.publish.label-confirm-override]
+original=Confirm overriding local version
+translation=Sentem asemselsi n lqem adigan
+
+[plugins.publish.label-confirm-override-1]
+original=Are you sure you want to override the local version?
+translation=Tebɣiḍ s tidet ad tsemselsiḍ lqem adigan?
+
+[plugins.publish.label-confirm-override-2]
+original=The live version will be used and your local version will be discarded. Please make backups if necessary.
+translation=Lqem amiran ad yettuseqdec yerna lqem-ik·im adigan ad yettwakkes. Ttxil-k·m· xdem iḥrazen ma yella yewwid.
+
+[plugins.publish.button-proceed]
+original=Proceed
+translation=Kemmel
+
+[plugins.publish.message-successfully-used-live-version]
+original=Successfully used live version to override your local version.
+translation=Aseqdec n lqem amiran i usemselsi n lqem-ik·im adigan yedda.
+
+[plugins.publish.label-open-in-live-site]
+original=Open in live site
+translation=Ldi deg usmel amiran
+
+[plugins.publish.label-open-file]
+original=Open file
+translation=Ldi afaylu
+
+[plugins.publish.tooltip-manage-publish-filters]
+original=Manage publish filters
+translation=Sefrek tistayin n tsuffeɣt
+
+[plugins.publish.option-included-folders]
+original=Included folders
+translation=Ikaramen yettwaseddun
+
+[plugins.publish.option-included-folders-desc]
+original=Files under these folders will automatically be selected when you review changes to publish.
+translation=Ifuyla ddaw n yikaramen-a ad ttwafernen s wudem awurman mi ara tesnekdeḍ ibeddilen i tsuffeɣt.
+
+[plugins.publish.option-currently-included-folders]
+original= These folders are currently included:
+translation= Ikaramen-a ttwaseddun tura:
+
+[plugins.publish.option-excluded-folders]
+original=Excluded folders
+translation=Ikaramen yettwastixren
+
+[plugins.publish.option-excluded-folders-desc]
+original=Files under these folders won't show up when you review changes to publish. This setting takes priority over included folders above.
+translation=Ifuyla ddaw n yikaramen-a ur d-ttbanen ara mi ara tesnekdeḍ ibeddilen i tsuffeɣt. Tawila-ya tesɛa tazwart ɣef yikaramen yettwaseddun ufella.
+
+[plugins.publish.label-number-of-folders-included]
+original=Obsidian Publish is currently including {{folders}}.
+translation=Tasuffeɣt Obsidian tsedday tura {{folders}}.
+
+[plugins.publish.label-number-of-folders-excluded]
+original=Obsidian Publish is currently excluding {{folders}}.
+translation=Tasuffeɣt Obsidian testixxir tura {{folders}}.
+
+[plugins.publish.label-manage-included-folders]
+original=Manage included folders
+translation=Sefrek ikaramen yettwaseddun
+
+[plugins.publish.label-manage-excluded-folders]
+original=Manage excluded folders
+translation=Sefrek ikaramen yettwastixren
+
+[plugins.publish.label-add-included-folder]
+original=Include a folder
+translation=Seddu akaram
+
+[plugins.publish.label-add-included-folder-desc]
+original=You can include both existing folders and folders that have not been created yet.
+translation=Tzemreḍ ad tsedduyḍ ikaramen yellan yakan d yikaramen ur d-nennulfa ara yakan.
+
+[plugins.publish.tooltip-contact-support]
+original=Contact support
+translation=Nermes tallalt
+
+[plugins.publish.label-navigation-preview]
+original=Navigation preview
+translation=Azarskan n tunigin
+
+[plugins.workspaces.name]
+original=Workspaces
+translation=Tallunin n umahil
+
+[plugins.workspaces.desc]
+original=Save and load workspace layouts.
+translation=Sekles yerna sali iɣawasen n tallunt n umahil.
+
+[plugins.workspaces.action-load-layout]
+original=Load workspace layout
+translation=Sali aɣawas n tallunt n umahil
+
+[plugins.workspaces.action-manage-layouts]
+original=Manage workspace layouts
+translation=Sefrek iɣawasen n tallunt n umahil
+
+[plugins.workspaces.action-save]
+original=Save layout
+translation=Sekles aɣawas
+
+[plugins.workspaces.action-save-and-load-layout]
+original=Save and load another layout
+translation=Sekles yerna sali aɣawas nniḍen
+
+[plugins.workspaces.placeholder-save-current-layout-as]
+original=Save current workspace layout as...
+translation=Sekles aɣawas amiran n tallunt n umahil am...
+
+[plugins.workspaces.button-save]
+original=Save
+translation=Sekles
+
+[plugins.workspaces.button-load]
+original=Load
+translation=Sali
+
+[plugins.workspaces.tooltip-delete-layout]
+original=Delete layout
+translation=Kkes aɣawas
+
+[plugins.workspaces.msg-enter-name]
+original=Please enter a name for the new layout.
+translation=Ttxil-k·m sekcem isem i uɣawas amaynut.
+
+[plugins.workspaces.msg-save-layout-success]
+original=Successfully saved layout “{{name}}”
+translation=Asekles n uɣawas “{{name}}” yedda.
+
+[plugins.workspaces.label-no-layout-found]
+original=No saved layout found.
+translation=Ulac aɣawas yettwaseklesen i yettwafan.
+
+[plugins.workspaces.label-workspace-modified-time]
+original=Modified {{time}}
+translation=Yettwabeddel {{time}}
+
+[plugins.workspaces.placeholder-type-to-search-layouts]
+original=Type layout name...
+translation=Aru isem n uɣawas...
+
+[plugins.sync.name]
+original=Sync
+translation=Amtawa
+
+[plugins.sync.desc]
+original=Synchronize your files through Obsidian Sync.
+translation=Mtawi ifuyla-k·m s Umtawa n Obsidian. 
+
+[plugins.sync.action-view-version-history]
+original=Open version history for the current file
+translation=Ldi azray n lqem i ufaylu amiran. 
+
+[plugins.sync.action-setup-sync]
+original=Set up Sync
+translation=Swel Amtawa 
+
+[plugins.sync.menu-opt-view-version-history]
+original=Open version history
+translation=Ldi azray n lqem
+
+[plugins.sync.action-view-sync-sidebar]
+original=Show Sync history
+translation=Sken azray n Umtawa
+
+[plugins.sync.action-activity-log]
+original=Open activity log
+translation=Ldi aɣmis n warmud
+
+[plugins.sync.label-load-more]
+original=Load more
+translation=Sali-d ugar
+
+[plugins.sync.label-show-diff]
+original=Show changes
+translation=Sken ibeddilen
+
+[plugins.sync.label-copy-to-clipboard]
+original=Copy to clipboard
+translation=Nɣel ɣer tecfawit
+
+[plugins.sync.label-restore-this-version]
+original=Restore
+translation=Err-d
+
+[plugins.sync.msg-already-latest-version]
+original=This version is already the latest version.
+translation=Lqem-a d aneggaru yakan.
+
+[plugins.sync.msg-restored-version]
+original=Successfully restored version from {{time}}
+translation=Lqem n {{time}} yettwarra-d akken iwata
+
+[plugins.sync.label-file-deleted]
+original=This file was deleted
+translation=Afaylu-a yettwakkes
+
+[plugins.sync.label-file-deleted-via]
+original=Deleted via {{ device }}
+translation=Yettwakkes sɣur {{ device }}
+
+[plugins.sync.label-file-renamed-from]
+original=Renamed from “{{from}}”
+translation=Yettwabeddel isem-is seg “{{from}}”
+
+[plugins.sync.label-file-renamed-from-to]
+original=Renamed from “{{from}}” to “{{to}}”
+translation=Yettwabeddel isem-is seg “{{from}}” ɣer “{{to}}”
+
+[plugins.sync.label-file-moved-from]
+original=Moved from “{{from}}”
+translation=Yettwasmutti seg “{{from}}”
+
+[plugins.sync.label-file-moved-from-to]
+original=Moved from “{{from}}” to “{{to}}”
+translation=Yettwasmutti seg “{{from}}” ɣer “{{to}}”
+
+[plugins.sync.label-revision]
+original={{count}} revision
+translation={{count}} n lqem
+
+[plugins.sync.label-revision_plural]
+original={{count}} revisions
+translation={{count}} n yileqman
+
+[plugins.sync.label-via-device]
+original=via {{device}}
+translation=sɣur {{device}}
+
+[plugins.sync.label-no-history]
+original=No sync history for this file.
+translation=Ulac azray n umtawa i ufaylu-a. 
+
+[plugins.sync.label-empty-file]
+original=Empty content
+translation=Agbur ilem
+
+[plugins.sync.label-unable-to-retrieve]
+original=Unable to retrieve version history
+translation=D awezɣi asider n uzray n yileqman
+
+[plugins.sync.label-setting-files]
+original=Setting files
+translation=Ifuyla n yiɣewwaṛen
+
+[plugins.sync.label-deleted-files]
+original=Deleted files
+translation=Ifuyla yettwakksen
+
+[plugins.sync.label-version-history]
+original=Version history
+translation=Amzray n yileqman
+
+[plugins.sync.label-click-to-see-history]
+original=Click on a file to see its history.
+translation=Sit ɣef ufaylu i wakken ad twaliḍ amezruy-is.
+
+[plugins.sync.label-create-remote-vault]
+original=Create remote vault
+translation=Rnu akaram n weḥraz anmeggag
+
+[plugins.sync.msg-please-enter-password]
+original=Please enter a password.
+translation=Ttxil-k·m sekcem awal n uɛeddi.
+
+[plugins.sync.msg-vault-name-cannot-be-empty]
+original=Vault name cannot be empty.
+translation=Isem n ukaram n weḥraz ur yezmir ara ad yili d ilem. 
+
+[plugins.sync.msg-successfully-created-vault]
+original=Successfully created remote vault “{{name}}”.
+translation=Asnulfu n ukaram n weḥraz anmeggag “{{name}}” yedda akken iwata. 
+
+[plugins.sync.label-remote-vault-explanation]
+original=Remote vaults securely synchronize your vault between devices.
+translation=Ikaramen n weḥraz inmeggagen mtawan akaram-ik·im n weḥraz gar yibenkan s tɣellist. 
+
+[plugins.sync.option-vault-name]
+original=Vault name
+translation=Isem n ukaram n weḥraz
+
+[plugins.sync.option-vault-name-desc]
+original=Helps you remember what this vault is for.
+translation=Ad k-id-yefk tallalt ad tecfuḍ ɣef wacu yettwaxdem ukaram-a n weḥraz. 
+
+[plugins.sync.option-vault-region]
+original=Region
+translation=Tamnaḍt
+
+[plugins.sync.opt-vault-region-automatic]
+original=Automatic
+translation=Awurman
+
+[plugins.sync.option-vault-region-desc]
+original=Select the server region closest to you to store the remote vault. This cannot be changed in the future.
+translation=Fren tamnaḍt n uqeddac i d-iqerben ɣuṛ-k·m i wakken ad teskelseḍ akaram n weḥraz anmeggag. Aya ur yezmir ara ad yettwabeddel ɣer zdat. 
+
+[plugins.sync.option-vault-name-placeholder]
+original=My awesome vault
+translation=Akaram-iw n weḥraz igerrzen
+
+[plugins.sync.option-encryption]
+original=Encryption
+translation=Awgelhen
+
+[plugins.sync.option-encryption-desc]
+original=End-to-end encryption offers the strongest security but requires you to safely store your encryption password. Standard encryption uses a key managed by Obsidian to protect your data in transit and on our servers.
+translation=Awgelhen seg yixef ɣer yixef yettak-d taɣellist i yiǧehden ugar maca issefk fell-ak·am ad tḥerzeḍ awal n uɛeddi n uwgelhen-ik·im s tɣellist. Awgelhen amezwer yesseqdac tasarut yettusefraken sɣur Obsidian i wakken ad iḥrez isefka-k·m ma ara tt-ddun neɣ ma ara ilin ɣef yiqeddacen-nneɣ. 
+
+[plugins.sync.option-encryption-warning]
+original=This option cannot be changed later.
+translation=Taxtiṛit-a ur tezmir ara ad tettwabeddel sakin. 
+
+[plugins.sync.option-encryption-end-to-end]
+original=End-to-end encryption
+translation=Awgelhen seg yixef ɣer yixef
+
+[plugins.sync.option-encryption-standard]
+original=Standard encryption
+translation=Awgelhen n tizeɣt
+
+[plugins.sync.option-encryption-password]
+original=Encryption password
+translation=Awal n uɛeddi n uwgelhen
+
+[plugins.sync.option-encryption-password-desc]
+original=This password cannot be changed later.
+translation=Awal-a n uɛeddi ur yezmir ara ad yettwabeddel sakin.
+
+[plugins.sync.option-encryption-password-desc-warning]
+original=If you forget this password, any remote data will remain unusable forever.
+translation=Ma tettuḍ awal-a n uɛeddi, kra n yisefka inmeggagen ur ttezmiren ara ad ttuseqdcen i lebda. 
+
+[plugins.sync.option-encryption-password-desc-2]
+original=This does not affect your local data.
+translation=Aya ur yettḥaza ara isefka-k·m idiganen.
+
+[plugins.sync.label-encryption-password-explanation]
+original=The remote vault “{{name}}” is currently encrypted. Enter your password to unlock.
+translation=Akaram n weḥraz anmeggag “{{name}}” yettwawgelhen tura. Sekcem awal-ik·im n uɛeddi i wesriḥ. 
+
+[plugins.sync.option-encryption-password-placeholder]
+original=Your password
+translation=Awal-ik·im n uɛeddi
+
+[plugins.sync.label-unlock-encrypted-vault]
+original=Unlock your remote vault
+translation=Serreḥ akaram-ik·im n weḥraz anmeggag
+
+[plugins.sync.button-unlock-vault]
+original=Unlock vault
+translation=Serreḥ akaram n weḥraz
+
+[plugins.sync.label-remote-vaults]
+original=Your remote vaults
+translation=Ikaramen-ik·im n weḥraz inmeggagen
+
+[plugins.sync.label-vault-created-time]
+original=Created {{time}}
+translation=Yennulfa-d deg {{time}}
+
+[plugins.sync.tooltip-delete-remote-vault]
+original=Delete
+translation=Kkes
+
+[plugins.sync.tooltip-rename-remote-vault]
+original=Rename
+translation=Beddel isem
+
+[plugins.sync.label-rename-remote-vault]
+original=Rename remote vault “{{name}}”
+translation=Beddel isem n ukaram n weḥraz anmeggag “{{name}}”
+
+[plugins.sync.label-rename-remote-vault-desc]
+original=Enter a new name for this remote vault.
+translation=Sekcem isem amaynut i ukaram-a n weḥraz anmeggag.
+
+[plugins.sync.tooltip-manage-sharing]
+original=Manage sharing
+translation=Sefrek beṭṭu
+
+[plugins.sync.label-confirm-delete-remote-vault]
+original=Confirm delete vault
+translation=Sentem tukksa n ukaram n weḥraz
+
+[plugins.sync.label-confirm-delete-remote-vault-question]
+original=Are you sure you want to delete the remote vault "{{name}}"?
+translation=Tebɣiḍ s tidet ad tekkseḍ akaram n weḥraz anmeggag "{{name}}"? 
+
+[plugins.sync.label-confirm-delete-remote-vault-result]
+original=All data on our server, including version history, will be deleted. Your local files will stay intact.
+translation=Akk isefka ɣef uqeddac-nneɣ, gar-asen amezruy n yileqman, ad ttwakksen. Ifuyla-k·m idiganen ad qqimen akken llan. 
+
+[plugins.sync.label-confirm-delete-remote-vault-warning]
+original=This action is permanent and irreversible.
+translation=Tigawt-a d timezgit yerna ur tezmir ara ad tettwasemmet.
+
+[plugins.sync.msg-remote-vault-deleted]
+original={{name}} has been deleted.
+translation={{name}} yettwakkes. 
+
+[plugins.sync.msg-disconnect-from-deleted-vault]
+original=Obsidian Sync: The connected remote vault no longer exists.
+translation=Amtawa n Obsidian: Akaram n weḥraz anmeggag yeqqnen ulac-it dayen. 
+
+[plugins.sync.button-connect-to-remote-vault]
+original=Connect
+translation=Qqen
+
+[plugins.sync.button-disconnect-from-remote-vault]
+original=Disconnect
+translation=Senser
+
+[plugins.sync.label-sync-status]
+original=Sync: {{status}}
+translation=Amtawa: {{status}}
+
+[plugins.sync.label-not-remote-vaults]
+original=You don't have any remote vaults.
+translation=Ur tesɛiḍ ula d yiwen ukaram n weḥraz anmeggag.
+
+[plugins.sync.label-no-subscription]
+original=You don't have an active Obsidian Sync subscription.
+translation=Ur tesɛiḍ ara amtawa n Umtawa Obsidian yermden.
+
+[plugins.sync.label-please-visit]
+original=Please visit
+translation=Ttxil-k·m rzu.
+
+[plugins.sync.label-preview-unsupported-file-type]
+original=Unable to preview {{type}} files.
+translation=D awezɣi azarskan n yifuyla n {{type}}. 
+
+[plugins.sync.button-create-new-remote-vault]
+original=Create new vault
+translation=Rnu akaram amaynut n weḥraz
+
+[plugins.sync.label-sync-log]
+original=Sync log
+translation=Aɣmis n umtawa
+
+[plugins.sync.option-event-type-all]
+original=All
+translation=Akk
+
+[plugins.sync.option-event-type-errors]
+original=Errors
+translation=Tuccḍiwin 
+
+[plugins.sync.option-event-type-skipped]
+original=Skipped
+translation=Yettwazgel
+
+[plugins.sync.option-event-type-merge-conflicts]
+original=Merge conflicts
+translation=Imgirrad n wezday 
+
+[plugins.sync.button-copy-sync-log]
+original=Copy sync log
+translation=Nɣel aɣmis n umtawa 
+
+[plugins.sync.msg-successfully-copied-sync-log]
+original=Successfully copied sync log.
+translation=Aɣmis n umtawa yettwanɣel s wudem imeɣtu.
+
+[plugins.sync.button-retry]
+original=Retry
+translation=Ales aɛraḍ
+
+[plugins.sync.button-purchase-subscription]
+original=Purchase
+translation=Aɣ [cite: 163]
+
+[plugins.sync.label-third-party-sync-warning]
+original=Conflicting file sync service detected
+translation=Ameẓlu n umtawa n yifuyla s wemgirred yettwaf 
+
+[plugins.sync.label-third-party-sync-warning-desc]
+original=Warning: Your vault seems to be using {{service}} as a third party sync service. If you use Obsidian Sync with this vault, you may run into conflicts, file corruption, or data loss.
+translation=Ɣur-k·m: akaram-ik·im n weḥraz yettban-d iseqdac {{service}} am umeẓlu n umtawa n wis kraḍ. Ma tseqdaceḍ Amtawa Obsidian d ukaram-a n weḥraz, tzemreḍ ad temlileḍ d yimgirrad, axsaṛ n yifuyla, neɣ asṛuḥu n yisefka. 
+
+[plugins.sync.label-icloud-drive-warning]
+original=If you are using iCloud Drive, your Documents and Desktop folders might be synced by iCloud. This could cause conflicts with Obsidian Sync.
+translation=Ma tseqdaceḍ iCloud Drive, ikaramen-ik·im Isemliyen d Tnarit zemren ad ttwamtawan sɣur iCloud. Aya yezmer ad d-yeglu s yimgirrad d Umtawa n Obsidian. 
+
+[plugins.sync.option-remote-vault]
+original=Remote vault
+translation=Akaram n weḥraz anmeggag 
+
+[plugins.sync.button-choose-remote-vault]
+original=Choose
+translation=Fren 
+
+[plugins.sync.button-manage-remote-vault]
+original=Manage
+translation=Sefrek 
+
+[plugins.sync.option-remote-vault-desc-connected]
+original=Currently connected to the “{{name}}” remote vault.
+translation=Yeqqen tura ɣer ukaram n weḥraz anmeggag “{{name}}”. 
+
+[plugins.sync.option-remote-vault-desc-not-connected]
+original=Currently not connected to any remote vault.
+translation=Ur yeqqin ara tura ɣer ula d yiwen ukaram n weḥraz anmeggag.
+
+[plugins.sync.option-sync-status]
+original=Sync status
+translation=Addad n umtawa 
+
+[plugins.sync.option-sync-status-desc-paused]
+original=Obsidian Sync is currently paused.
+translation=Amtawa Obsidian yettwaserǧu tura.
+
+[plugins.sync.option-sync-status-desc-running]
+original=Obsidian Sync is currently running.
+translation=Amtawa Obsidian iteddu tura. 
+
+[plugins.sync.option-device-name]
+original=Device name
+translation=Isem n yibenk 
+
+[plugins.sync.option-device-name-desc]
+original=This name will be displayed in the activity log. Leave empty to use the default name.
+translation=Isem-a ad d-yettwabeqqeḍ deg uɣmis n warmud. Eǧǧ-it d ilem i useqdec n yisem amezwer. 
+
+[plugins.sync.button-resume]
+original=Resume
+translation=Kemmel 
+
+[plugins.sync.button-pause]
+original=Pause
+translation=Serǧu
+
+[plugins.sync.option-view-deleted-files]
+original=Deleted files
+translation=Ifuyla yettwakksen 
+
+[plugins.sync.option-view-deleted-files-desc]
+original=View and restore deleted files.
+translation=Sken yerna err-d ifuyla yettwakksen. 
+
+[plugins.sync.option-sync-log]
+original=Activity log
+translation=Aɣmis n warmud 
+
+[plugins.sync.option-sync-log-desc]
+original=View recent sync activities for debugging.
+translation=Sken irmaden n umtawa ineggura i useɣti. 
+
+[plugins.sync.button-view]
+original=View
+translation=Sken 
+
+[plugins.sync.button-bulk-restore]
+original=Bulk restore
+translation=Tiririt s ujemmal 
+
+[plugins.sync.button-restore-files_zero]
+original=Restore files
+translation=Err-d ifuyla 
+
+[plugins.sync.button-restore-files]
+original=Restore {{count}} file
+translation=Err-d {{count}} ufaylu
+
+[plugins.sync.button-restore-files_plural]
+original=Restore {{count}} files
+translation=Err-d {{count}} n yifuyla
+
+[plugins.sync.msg-restoring]
+original=Restoring...
+translation=Tiririt tura... 
+
+[plugins.sync.msg-restoring-complete]
+original=Restore complete: {{succeeded}} succeeded and {{failed}} failed.
+translation=Tiririt tekfa: {{succeeded}} ddan yerna {{failed}} ccḍen. 
+
+[plugins.sync.option-vault-size]
+original=Storage usage
+translation=Aseqdec n usekles 
+
+[plugins.sync.option-vault-size-desc]
+original=You are using {{size}} out of {{limit}}
+translation=Tseqdaceḍ {{size}} seg {{limit}}
+
+[plugins.sync.option-vault-size-unknown]
+original=Unable to retrieve your vault size.
+translation=D awezɣi asider n tiddi n ukaram-ik·im n weḥraz. 
+
+[plugins.sync.option-vault-size-loading]
+original=Retrieving your vault size...
+translation=Asider n tiddi n ukaram-ik·im n weḥraz...
+
+[plugins.sync.option-over-size]
+original=Vault size over limit
+translation=Tiddi n ukaram n weḥraz tugar talast 
+
+[plugins.sync.option-almost-over-size]
+original=Vault size approaching limit
+translation=Tiddi n ukaram n weḥraz teqṛeb ɣer talast
+
+[plugins.sync.msg-largest-files]
+original=View largest files
+translation=Sken ifuyla imeqranen 
+
+[plugins.sync.msg-largest-files-desc]
+original=These are the remote files that are taking the most space. After deleting attachments, use the purge button to free up remote vault space.
+translation=Wigi d ifuyla inmeggagen i yeṭṭfen aṭas n tallunt. Deffir tukksa n yimeddayen, seqdec taqeffalt n usenger i wesriḥ n tallunt n ukaram n weḥraz anmeggag. 
+
+[plugins.sync.button-upgrade-storage]
+original=Upgrade storage
+translation=Snerni asekles 
+
+[plugins.sync.button-purge-remote]
+original=Purge
+translation=Senger
+
+[plugins.sync.button-hide-my-changes]
+original=Hide my changes
+translation=Ffer ibeddilen-iw
+
+[plugins.sync.tooltip-purge-remote]
+original=Permanently purge deleted attachments from remote vault to save space.
+translation=Senger s wudem imezgi imeddayen yettwakksen seg ukaram n weḥraz anmeggag i wesriḥ n tallunt.
+
+[plugins.sync.msg-purge-complete]
+original=Purge complete.
+translation=Asenger yekfa.
+
+[plugins.sync.option-prevent-sleep]
+original=Prevent device sleep
+translation=Sewḥel iḍeṣ n yibenk
+
+[plugins.sync.option-prevent-sleep-desc]
+original=Prevents the device from going to sleep when there are still files to be synced.
+translation=Yessewḥal ibenk ad yeṭṭes mi mazal llan yifuyla ara yettwamtawan.
+
+[plugins.sync.option-selective-sync]
+original=Selective sync
+translation=Amtawa afrayan
+
+[plugins.sync.option-excluded-folders]
+original=Excluded folders
+translation=Ikaramen yettwastixren
+
+[plugins.sync.option-excluded-folder-desc]
+original=Prevent certain folders from being synced.
+translation=Sewḥel kra n yikaramen seg umtawa.
+
+[plugins.sync.option-currently-excluded-folders]
+original= These folders are currently excluded:
+translation= Ikaramen-a ttwastixren tura:
+
+[plugins.sync.button-manage-excluded-folders]
+original=Manage
+translation=Sefrek
+
+[plugins.sync.option-sync-image]
+original=Sync images
+translation=Mtawi tugniwin
+
+[plugins.sync.option-sync-image-desc]
+original=Sync image files with these extensions: {{extensions}}.
+translation=Mtawi ifuyla n tugniwin s yisiɣzaf-a: {{extensions}}.
+
+[plugins.sync.option-sync-audio]
+original=Sync audio
+translation=Mtawi imesli
+
+[plugins.sync.option-sync-audio-desc]
+original=Sync audio files with these extensions: {{extensions}}.
+translation=Mtawi ifuyla n yimesli s yisiɣzaf-a: {{extensions}}.
+
+[plugins.sync.option-sync-video]
+original=Sync videos
+translation=Mtawi video
+
+[plugins.sync.option-sync-video-desc]
+original=Sync video files with these extensions: {{extensions}}.
+translation=Mtawi ifuyla n video s yisiɣzaf-a: {{extensions}}.
+
+[plugins.sync.option-sync-pdf]
+original=Sync PDFs
+translation=Mtawi ifuyla PDF
+
+[plugins.sync.option-sync-pdf-desc]
+original=Sync PDF files.
+translation=Mtawi ifuyla PDF.
+
+[plugins.sync.option-sync-unsupported]
+original=Sync all other types
+translation=Mtawi akk tiwsatin nniḍen
+
+[plugins.sync.option-sync-unsupported-desc]
+original=Sync unsupported file types.
+translation=Mtawi tiwsatin n yifuyla ur nettusefrak ara.
+
+[plugins.sync.option-vault-config-sync]
+original=Vault configuration sync
+translation=Amtawa n twila n ukaram n weḥraz
+
+[plugins.sync.option-view-config-files]
+original=Settings version history
+translation=Amezruy n yileqman n yiɣewwaṛen
+
+[plugins.sync.option-view-config-files-desc]
+original=View and restore version history of setting files.
+translation=Sken yerna err-d amezruy n yileqman n yifuyla n yiɣewwaṛen.
+
+[plugins.sync.option-sync-app]
+original=Main settings
+translation=Iɣewwaṛen igejdanen
+
+[plugins.sync.option-sync-app-desc]
+original=Enable to sync editor settings, files & links settings, etc.
+translation=Sermed i umtawa n yiɣewwaṛen n umaẓrag, iɣewwaṛen n yifuyla d yiseɣwan, atg.
+
+[plugins.sync.option-sync-appearance]
+original=Appearance settings
+translation=Iɣewwaṛen n timeẓri
+
+[plugins.sync.option-sync-appearance-desc]
+original=Sync appearance settings like dark mode, active theme, and enabled snippets.
+translation=Mtawi iɣewwaṛen n timeẓri am waskar ubrik, asentel urmid, d yiḥricen n tengalt yermden.
+
+[plugins.sync.option-sync-appearance-data]
+original=Themes and snippets
+translation=Isental d yiḥricen n tengalt
+
+[plugins.sync.option-sync-appearance-data-desc]
+original=Sync downloaded themes and snippets. Whether they are enabled depends on the previous setting.
+translation=Mtawi isental d yiḥricen n tengalt yettwasidren. Ma yella remden neɣ ala, yeṭṭef deg uɣewwaṛ yezrin.
+
+[plugins.sync.option-sync-hotkey]
+original=Hotkeys
+translation=Tiqeffalin n unegzum
+
+[plugins.sync.option-sync-hotkey-desc]
+original=Sync custom hotkeys.
+translation=Mtawi tiqeffalin n unegzum yettusagenen.
+
+[plugins.sync.option-sync-core-plugin]
+original=Active core plugin list
+translation=Tabdart n yizegrar igejdanen urmiden
+
+[plugins.sync.option-sync-core-plugin-desc]
+original=Sync which core plugins are enabled.
+translation=Mtawi anwi izegrar igejdanen i yermden.
+
+[plugins.sync.option-sync-core-plugin-data]
+original=Core plugin settings
+translation=Iɣewwaṛen n yizegrar igejdanen
+
+[plugins.sync.option-sync-core-plugin-data-desc]
+original=Sync core plugin settings.
+translation=Mtawi iɣewwaṛen n yizegrar igejdanen.
+
+[plugins.sync.option-sync-community-plugin]
+original=Active community plugin list
+translation=Tabdart n yizegrar n umɣiwan urmiden
+
+[plugins.sync.option-sync-community-plugin-desc]
+original=Sync which community plugins are enabled.
+translation=Mtawi anwi izegrar n umɣiwan i yermden.
+
+[plugins.sync.option-sync-community-plugin-data]
+original=Installed community plugins
+translation=Izegrar n umɣiwan yettwasbedden
+
+[plugins.sync.option-sync-community-plugin-data-desc]
+original=Sync installed community plugins (.js, .css, and manifest.json files) and their settings.
+translation=Mtawi izegrar n umɣiwan yettwasbedden (ifuyla .js, .css, d manifest.json) d yiɣewwaṛen-nsen.
+
+[plugins.sync.label-sync-loading]
+original=Sync is still loading, please refresh this page later.
+translation=Amtawa mazal yettali-d, ttxil-k·m ales asali n usebter-a sakin.
+
+[plugins.sync.label-sync-introduction]
+original=Obsidian Sync is Obsidian's add-on sync service with end-to-end encryption and version history.
+translation=Amtawa n Obsidian d ameẓlu n umtawa yernan n Obsidian s uwgelhen seg yixef ɣer yixef d umezruy n yileqman.
+
+[plugins.sync.label-account-required]
+original=To start syncing, please log in or create a new Obsidian account.
+translation=I wakken ad tebduḍ amtawa, ttxil-k·m kcem neɣ rnu amiḍan amaynut Obsidian.
+
+[plugins.sync.label-current-file]
+original=Current file
+translation=Afaylu amiran
+
+[plugins.sync.label-sync-changes]
+original=Sync changes
+translation=Mtawi ibeddilen
+
+[plugins.sync.label-today]
+original=Today
+translation=Ass-a
+
+[plugins.sync.label-yesterday]
+original=Yesterday
+translation=Iḍelli
+
+[plugins.sync.label-this-week]
+original=This week
+translation=Imalas-a
+
+[plugins.sync.label-older]
+original=Older
+translation=Aqbur
+
+[plugins.sync.label-last-sync]
+original=Last sync
+translation=Amtawa aneggaru
+
+[plugins.sync.label-more]
+original={{count}} more
+translation={{count}} nniḍen
+
+[plugins.sync.button-sign-up]
+original=Sign up
+translation=Jerred
+
+[plugins.sync.button-log-in]
+original=Log in
+translation=Kcem
+
+[plugins.sync.label-manage-excluded-folders]
+original=Manage excluded folders
+translation=Sefrek ikaramen yettwastixren
+
+[plugins.sync.label-number-of-folders-excluded]
+original=Obsidian Sync is currently excluding {{folders}}.
+translation=Amtawa n Obsidian yestixxir tura {{folders}}.
+
+[plugins.sync.label-add-excluded-folder]
+original=Exclude a folder
+translation=Stixer akaram
+
+[plugins.sync.label-add-excluded-folder-desc]
+original=You can exclude both existing folders and folders that have not been created yet.
+translation=Tzemreḍ ad testixreḍ ikaramen yellan yakan d yikaramen ur d-nennulfa ara yakan.
+
+[plugins.sync.tooltip-remove-excluded-folder]
+original=Remove from excluded list
+translation=Kkes seg tebdart yettwastixren
+
+[plugins.sync.label-setup-connection]
+original=Setup connection
+translation=Swel tuqqna
+
+[plugins.sync.label-connecting-to-vault]
+original=Connecting...
+translation=Tuqqna tura...
+
+[plugins.sync.label-connection-failed]
+original=Connection failed
+translation=Tecceḍ tuqqna
+
+[plugins.sync.label-connection-failed-desc]
+original=Failed to connect to remote vault.
+translation=Tecceḍ tuqqna ɣer ukaram n weḥraz anmeggag.
+
+[plugins.sync.label-now-connected-to-vault]
+original=You're now connected to “{{name}}”.
+translation=Teqqneḍ tura ɣer “{{name}}”.
+
+[plugins.sync.button-start-syncing]
+original=Start syncing
+translation=Bdu amtawa
+
+[plugins.sync.label-confirm-merge-vault]
+original=Confirm Merge Vault
+translation=Sentem azday n ukaram n weḥraz
+
+[plugins.sync.msg-vault-has-notes]
+original=Your local vault already contains some notes.
+translation=Akaram-ik·im n weḥraz adigan yesɛa yakan kra n tezmiltin.
+
+[plugins.sync.msg-vault-merge-warning]
+original=If you connect to the remote vault “{{name}}”, notes in your local vault will be merged with notes from your remote vault. In case of conflicts, the most recent version of the note will be preserved.
+translation=Ma teqqneḍ ɣer ukaram n weḥraz anmeggag “{{name}}”, tizmiltin deg ukaram-ik·im n weḥraz adigan ad ttwezdayent d tezmiltin seg ukaram-ik·im n weḥraz anmeggag. Deg tegnit n wemgirred, lqem aneggaru n tezmilt ad yettwaḥrez.
+
+[plugins.sync.tooltip-update-setting-on-all-devices]
+original=Please update this option and restart app on all the devices where you want it to take effect.
+translation=Ttxil-k·m mucceḍ taxtiṛit-a yerna ales asekker n usnas deg wakk ibenkan anda tebɣiḍ ad teddu.
+
+[plugins.sync.label-sharing-with-users]
+original=This remote vault is currently shared with the following people:
+translation=Akaram-a n weḥraz anmeggag yettwabḍa tura akked yemdanen-a:
+
+[plugins.sync.label-not-sharing]
+original=This remote vault is not currently shared with anyone.
+translation=Akaram-a n weḥraz anmeggag ur yettwabḍa d ula d yiwen tura.
+
+[plugins.sync.label-vaults-shared-with-you]
+original=Vaults shared with you
+translation=Ikaramen n weḥraz i d-yettwabḍan yid-k·m
+
+[plugins.sync.tooltip-leave-vault-sharing]
+original=Stop collaborating on this vault
+translation=Ḥbes amɛawan deg ukaram-a n weḥraz
+
+[plugins.sync.label-leave-vault-confirmation]
+original=Confirm stop vault collaboration
+translation=Sentem aḥbas n umɛawan n ukaram n weḥraz
+
+[plugins.sync.label-leave-vault-confirmation-details]
+original=This will remove this vault from the list of vaults shared with you. This action cannot be reverted.
+translation=Aya ad yekkes akaram-a n weḥraz seg tebdart n yikaramen n weḥraz i d-yettwabḍan yid-k·m. Tigawt-a ur tezmir ara ad tettwasemmet.
+
+[plugins.sync.label-leave-vault-confirmation-details-2]
+original=Please contact the owner of the vault if you wish to collaborate on this vault again.
+translation=Ttxil-k·m meslay d bab n ukaram n weḥraz ma tebɣiḍ ad tmɛawaneḍ deg ukaram-a n weḥraz tikkelt nniḍen.
+
+[plugins.sync.button-leave]
+original=Leave
+translation=Eǧǧ
+
+[plugins.sync.msg-error-failed-to-fetch]
+original=Failed to load remote vaults.
+translation=Yecceḍ usali n yikaramen n weḥraz inmeggagen.
+
+[plugins.sync.label-require-subscription-to-connect]
+original=You need an Obsidian Sync subscription to connect to this vault.
+translation=Teḥwaǧeḍ amtawa n Umtawa Obsidian i wakken ad teqqneḍ ɣer ukaram-a n weḥraz.
+
+[plugins.sync.option-contact-support]
+original=Contact support
+translation=Nermes tallalt
+
+[plugins.sync.option-contact-support-desc]
+original=If you run into any issues with Obsidian Sync, please contact us so we can help you out! You can reach us at support@obsidian.md.
+translation=Ma temlaleḍ d wuguren d Umtawa Obsidian, ttxil-k·m nermes-aɣ i wakken ad k-nallel! Tzemreḍ ad aɣ-d-tafeḍ ɣef support@obsidian.md.
+
+[plugins.sync.button-copy-debug]
+original=Copy debug info
+translation=Nɣel talɣut n useɣti
+
+[plugins.sync.button-email-support]
+original=Email support
+translation=Tallalt s yimayl
+
+[plugins.sync.label-sync-disconnected]
+original=Sync is not connected to a remote vault.
+translation=Amtawa ur yeqqin ara ɣer ukaram n weḥraz anmeggag.
+
+[plugins.sync.msg-remote-vault-limit-hit]
+original=You have created the maximum number of remote vaults. In order to create a new remote vault, please upgrade your account or remove an existing one.
+translation=Tesnulfaḍ-d amḍan afellay n yikaramen n weḥraz inmeggagen. I wakken ad tesnulfuḍ akaram n weḥraz anmeggag amaynut, ttxil-k·m sali aswir n umiḍan-ik·im neɣ kkes yiwen yellan.
+
+[plugins.sync.label-upgrade-vault]
+original=Upgrade vault
+translation=Sali aswir n ukaram n weḥraz
+
+[plugins.sync.label-upgrade-vault-encryption]
+original=Upgrade vault encryption
+translation=Sali aswir n uwgelhen n ukaram n weḥraz
+
+[plugins.sync.label-upgrade-vault-encryption-desc]
+original=There is a new encryption version available for remote vaults.
+translation=Yella lqem amaynut n uwgelhen i yikaramen n weḥraz inmeggagen.
+
+[plugins.sync.label-migrate-remote-vault]
+original=Migrate remote vault
+translation=Sinig akaram n weḥraz anmeggag
+
+[plugins.sync.label-remote-vault-configuration]
+original=Remote vault configuration
+translation=Tawila n ukaram n weḥraz anmeggag
+
+[plugins.sync.button-migrate]
+original=Migrate
+translation=Sinig
+
+[plugins.sync.msg-recreate-remote-vault]
+original=This will delete your remote vault and recreate it with the latest encryption. Local files will not be affected, however your version history will be lost.
+translation=Aya ad yekkes akaram-ik·im n weḥraz anmeggag yerna ad t-id-yesnulfu tikkelt nniḍen s uwgelhen aneggaru. Ifuyla idiganen ur ttwaḥazen ara, maca azray-ik·im n yileqman ad yeṛuḥ.
+
+[plugins.sync.label-confirm-migrate]
+original=Confirm vault migration
+translation=Sentem tunigin n ukaram n weḥraz
+
+[plugins.sync.msg-migrate-pre-confirmation-part1]
+original=To upgrade your encryption, all data in the vault will be re-uploaded to the Obsidian Sync servers using the new encryption method. This process will permanently delete all data encrypted with the old encryption, including the version history for your vault.
+translation=I wakken ad tsaliḍ aswir n uwgelhen-ik·im, akk isefka deg ukaram n weḥraz ad ttwasalin tikkelt nniḍen ɣer yiqeddacen n Umtawa Obsidian s useqdec n tarrayt tamaynut n uwgelhen. Akala-ya ad yekkes s wudem imezgi akk isefka yettwawgelhenen s uwgelhen aqdim, d uzray n yileqman n ukaram-ik·im n weḥraz.
+
+[plugins.sync.msg-migrate-pre-confirmation-part2]
+original=Important: we strongly recommend creating a backup of your vault before proceeding to prevent any potential data loss.
+translation=D axatar: nweṣṣa-k·m aṭas ad txedmeḍ aḥraz n ukaram-ik·im n weḥraz uqbel ad tkemmleḍ i wakken ad tsewḥeleḍ yal asṛuḥu n yisefka yezmren ad d-yili.
+
+[plugins.sync.msg-migrate-pre-confirmation-part3]
+original=After completing the upgrade, you will need to reconnect all your devices to the updated remote vault.
+translation=Deffir usali n weswir, ad teḥwaǧeḍ ad talseḍ tuqqna n wakk ibenkan-ik·im ɣer ukaram n weḥraz anmeggag yettwamuccḍen.
+
+[plugins.sync.msg-migrate-confirmation]
+original=Migrating your vault may take some time. You will need to keep Obsidian active on this device to re-upload all your notes and attachments. It is best to do this on your primary device.
+translation=Tunigin n ukaram-ik·im n weḥraz tezmer ad teṭṭef kra n wakud. Ad teḥwaǧeḍ ad teǧǧeḍ Obsidian yermed ɣef yibenk-a i wakken ad talseḍ asali n wakk tizmiltin-ik·im d yimeddayen-ik·im. Yif-it ma txedmeḍ aya ɣef yibenk-ik·im agejdan.
+
+[plugins.sync.msg-proceed-prompt]
+original=Do you want to proceed?
+translation=Tebɣiḍ ad tkemmleḍ?
+
+[plugins.sync.msg-vault-migration-started]
+original=Vault migration in progress.
+translation=Tunigin n ukaram n weḥraz la tteddu.
+
+[plugins.sync.msg-vault-migration-completed]
+original=Vault migration complete.
+translation=Tunigin n ukaram n weḥraz tekfa.
+
+[plugins.sync.label-resolve-conflicts]
+original=Conflict resolution
+translation=Ferru n yimgirrad
+
+[plugins.sync.label-resolve-conflicts-desc]
+original=Choose how conflicts are resolved when a note is independently modified on multiple devices.
+translation=Fren amek ara ttwafrun yimgirrad mi ara tettwabeddel tezmilt s wudem iman-is ɣef waṭas n yibenkan.
+
+[plugins.sync.option-automatic-merge]
+original=Automatically merge
+translation=Zdi s wudem awurman
+
+[plugins.sync.option-conflict-file]
+original=Create conflict file
+translation=Snulfu-d afaylu n wemgirred
+
+[plugins.file-recovery.name]
+original=File recovery
+translation=Tiririt n ufaylu
+
+[plugins.file-recovery.desc]
+original=Restore recent snapshots to recover from accidental data loss. Snapshots are only saved for Markdown files.
+translation=Err-d tuṭṭfiwin tineggura i wakken ad d-terreḍ isefka i yeṛuḥen s wudem n tuccḍa. Tuṭṭfiwin ttwaḥerzent kan i yifuyla Markdown.
+
+[plugins.file-recovery.action-open]
+original=Open local history
+translation=Ldi amezruy adigan
+
+[plugins.file-recovery.option-interval]
+original=Snapshot interval
+translation=Azilal n tuṭṭfa
+
+[plugins.file-recovery.option-interval-description]
+original=Minimal interval in minutes between two snapshots.
+translation=Azilal adday s tesdatin gar snat n tuṭṭfiwin.
+
+[plugins.file-recovery.option-keep]
+original=History length
+translation=Teɣzi n uzray
+
+[plugins.file-recovery.option-keep-description]
+original=Number of days the snapshots are kept for.
+translation=Amḍan n wussan i deg ttwaḥerzent tuṭṭfiwin.
+
+[plugins.file-recovery.option-open-history]
+original=Snapshots
+translation=Tuṭṭfiwin
+
+[plugins.file-recovery.option-open-history-description]
+original=View and restore saved snapshots.
+translation=Sken yerna err-d tuṭṭfiwin yettwaḥerzen.
+
+[plugins.file-recovery.button-view-history]
+original=View
+translation=Sken
+
+[plugins.file-recovery.option-clear]
+original=Clear history
+translation=Sfeḍ azray
+
+[plugins.file-recovery.option-clear-description]
+original=Delete all snapshots.
+translation=Kkes akk tuṭṭfiwin.
+
+[plugins.file-recovery.button-clear-history]
+original=Clear
+translation=Sfeḍ
+
+[plugins.file-recovery.label-clear-warning]
+original=Are you sure you want to delete all snapshots? Files inside your vault will not be affected.
+translation=Tebɣiḍ s tidet ad tekkseḍ akk tuṭṭfiwin? Ifuyla deg ukaram-ik·im n weḥraz ur ttwaḥazen ara.
+
+[plugins.file-recovery.msg-clear-complete]
+original=Local history cleared.
+translation=Amezruy adigan yettwasfeḍ.
+
+[plugins.file-recovery.label-no-history-found]
+original=Snapshots found.
+translation=Tuṭṭfiwin ttwafent.
+
+[plugins.file-recovery.placeholder-choose-file]
+original=Choose a file...
+translation=Fren afaylu...
+
+[plugins.file-recovery.label-select-file]
+original=Please select a file on the left to view snapshots.
+translation=Ttxil-k·m fren afaylu ɣef zelmeḍ i wakken ad twaliḍ tuṭṭfiwin.
+
+[plugins.note-composer.name]
+original=Note composer
+translation=Amesnulfu n tezmilt
+
+[plugins.note-composer.desc]
+original=Merge two notes or split one into two.
+translation=Zdi snat n tezmiltin neɣ bḍu yiwet ɣef snat.
+
+[plugins.note-composer.option-confirm-file-merge]
+original=Confirm file merge
+translation=Sentem azday n ufaylu
+
+[plugins.note-composer.option-confirm-file-merge-description]
+original=Prompt before merge two files.
+translation=Suter uqbel ad tezdiḍ sin yifuyla.
+
+[plugins.note-composer.option-split-replacement-text]
+original=Text after extraction
+translation=Aḍris deffir n tussfa
+
+[plugins.note-composer.option-split-replacement-text-description]
+original=What to show in place of the selected text after extracting it.
+translation=D acu ara d-tsekneḍ deg umkan n weḍris yettwafrenen deffir tussfa-ines.
+
+[plugins.note-composer.option-choice-split-replacement-text-link]
+original=Link to new file
+translation=Aseɣwen ɣer ufaylu amaynut
+
+[plugins.note-composer.option-choice-split-replacement-text-embed]
+original=Embed new file
+translation=Seddu afaylu amaynut
+
+[plugins.note-composer.option-choice-split-replacement-text-none]
+original=None
+translation=Ulac
+
+[plugins.note-composer.option-template-file]
+original=Template file location
+translation=Ideg n ufaylu n tmudemt
+
+[plugins.note-composer.option-template-file-description]
+original=Template file to use when merging or extracting. Available variables: {{content}}, {{fromTitle}}, {{newTitle}}, {{date:FORMAT}}, e.g. {{date:YYYY-MM-DD}}.
+translation=Afaylu n tmudemt ara yettuseqdec mi ara tezdiḍ neɣ ad tessefḍeḍ. Imuttiyen yestufan: {{content}}, {{fromTitle}}, {{newTitle}}, {{date:FORMAT}}, amedya {{date:YYYY-MM-DD}}.
+
+[plugins.note-composer.command-merge-file]
+original=Merge current file with another file...
+translation=Zdi afaylu amiran akked ufaylu nniḍen...
+
+[plugins.note-composer.action-merge-file]
+original=Merge entire file with...
+translation=Zdi afaylu ummid akked...
+
+[plugins.note-composer.label-no-files]
+original=No files found.
+translation=Ulac ifuyla i yettwafan.
+
+[plugins.note-composer.instruction-navigate]
+original=to navigate
+translation=i tunigin
+
+[plugins.note-composer.instruction-merge]
+original=to merge
+translation=i wezday
+
+[plugins.note-composer.instruction-create-new]
+original=to create new
+translation=i wesnulfu amaynut
+
+[plugins.note-composer.instruction-merge-at-top]
+original=to merge at top
+translation=i wezday ufella
+
+[plugins.note-composer.instruction-dismiss]
+original=to dismiss
+translation=i tukksa
+
+[plugins.note-composer.prompt-select-file-to-merge]
+original=Select file to merge into...
+translation=Fren afaylu i wezday deg-s...
+
+[plugins.note-composer.label-merge-file]
+original=Merge file
+translation=Zdi afaylu
+
+[plugins.note-composer.label-confirm-file-merge]
+original=Are you sure you want to merge “{{file}}” into “{{destination}}”? “{{file}}” will be deleted.
+translation=Tebɣiḍ s tidet ad tezdiḍ “{{file}}” ɣer “{{destination}}”? “{{file}}” ad yettwakkes.
+
+[plugins.note-composer.button-merge]
+original=Merge
+translation=Zdi
+
+[plugins.note-composer.command-split-file]
+original=Extract current selection...
+translation=Ssef tafrayt tamirant...
+
+[plugins.note-composer.command-extract-heading]
+original=Extract this heading...
+translation=Ssef tasenṭit-a...
+
+[plugins.note-composer.instruction-append]
+original=to move to bottom
+translation=i usmutti ɣer wadda
+
+[plugins.note-composer.instruction-prepend]
+original=to move to top
+translation=i usmutti ɣer ufella
+
+[plugins.note-composer.msg-fail-to-fetch-template]
+original=Failed to fetch template file: “{{template}}” not found.
+translation=Yecceḍ wawi n ufaylu n tmudemt: “{{template}}” ur yettwafa ara.
+
+[plugins.note-composer.msg-fail-to-find-heading]
+original=Failed to find heading
+translation=Ur yezmir ara ad yaf tasenṭit
+
+[plugins.web-viewer.name]
+original=Web viewer
+translation=Ameskan n Web
+
+[plugins.web-viewer.history-name]
+original=Web history
+translation=Azray n Web
+
+[plugins.web-viewer.desc]
+original=Open external links to web pages inside Obsidian.
+translation=Ldi iseɣwan uffiɣen ɣer isebtar Web daxel n Obsidian.
+
+[plugins.web-viewer.action-open]
+original=Open web viewer
+translation=Ldi ameskan n Web
+
+[plugins.web-viewer.action-show-history]
+original=Show history
+translation=Sken azray
+
+[plugins.web-viewer.action-toggle-reader-mode]
+original=Toggle reader mode
+translation=Qluqel askar n umeɣri
+
+[plugins.web-viewer.action-copy-u-r-l]
+original=Copy URL
+translation=Nɣel URL
+
+[plugins.web-viewer.action-remove-from-history]
+original=Remove from history
+translation=Kkes seg uzray
+
+[plugins.web-viewer.action-clear-history]
+original=Clear history
+translation=Sfeḍ azray
+
+[plugins.web-viewer.action-open-link]
+original=Open link
+translation=Ldi aseɣwen
+
+[plugins.web-viewer.action-open-link-new-tab]
+original=Open link in new tab
+translation=Ldi aseɣwen deg yiccer amaynut
+
+[plugins.web-viewer.action-open-link-new-split]
+original=Open link to the right
+translation=Ldi aseɣwen ɣer yeffus
+
+[plugins.web-viewer.action-open-link-new-window]
+original=Open link in new window
+translation=Ldi aseɣwen deg usfaylu amaynut
+
+[plugins.web-viewer.action-open-link-default-browser]
+original=Open link in default browser
+translation=Ldi aseɣwen deg yiminig amezwer
+
+[plugins.web-viewer.action-open-link-web-viewer]
+original=Open link in web viewer
+translation=Ldi aseɣwen deg umeskan n Web
+
+[plugins.web-viewer.action-copy-link-address]
+original=Copy link address
+translation=Nɣel tansa n useɣwen
+
+[plugins.web-viewer.action-bookmark-link]
+original=Bookmark link
+translation=Err aseɣwen d asɣal
+
+[plugins.web-viewer.action-search-for-query]
+original=Search for “{{query}}”
+translation=Nadi ɣef “{{query}}”
+
+[plugins.web-viewer.action-extract-selection]
+original=Extract selection to new note
+translation=Ssef tafrayt ɣer tezmilt tamaynut
+
+[plugins.web-viewer.action-copy-selection]
+original=Copy
+translation=Nɣel
+
+[plugins.web-viewer.action-cut]
+original=Cut
+translation=Gzem
+
+[plugins.web-viewer.action-paste]
+original=Paste
+translation=Senteḍ
+
+[plugins.web-viewer.action-delete]
+original=Delete
+translation=Kkes
+
+[plugins.web-viewer.action-select-all]
+original=Select all
+translation=Fren akk
+
+[plugins.web-viewer.action-save-to-vault]
+original=Save to vault
+translation=Sekles ɣer ukaram n weḥraz
+
+[plugins.web-viewer.action-save-image]
+original=Save image to vault
+translation=Sekles tugna ɣer ukaram n weḥraz
+
+[plugins.web-viewer.action-copy-image-link]
+original=Copy image link
+translation=Nɣel aseɣwen n tugna
+
+[plugins.web-viewer.action-backward]
+original=Backward
+translation=Ɣer deffir
+
+[plugins.web-viewer.action-forward]
+original=Forward
+translation=Ɣer zdat
+
+[plugins.web-viewer.action-reload]
+original=Reload
+translation=Ales asali
+
+[plugins.web-viewer.action-bookmark-page]
+original=Bookmark page
+translation=Err asebter d asɣal
+
+[plugins.web-viewer.action-open-default-browser]
+original=Open in default browser
+translation=Ldi deg yiminig amezwer
+
+[plugins.web-viewer.action-focus-address-bar]
+original=Focus address bar
+translation=Sers asaḍas ɣef tfeggagt n tansa
+
+[plugins.web-viewer.action-search-the-web]
+original=Search the web
+translation=Nadi deg Web
+
+[plugins.web-viewer.action-clear-data]
+original=Clear data
+translation=Sfeḍ isefka
+
+[plugins.web-viewer.action-clear-data-cookies]
+original=Cookies
+translation=Cookies
+
+[plugins.web-viewer.action-clear-data-cookies-desc]
+original=May sign you out of websites.
+translation=Yezmer ad k-id-yessufeɣ seg yismalen Web.
+
+[plugins.web-viewer.action-clear-data-cache]
+original=Cached data
+translation=Isefka n tzarkatut
+
+[plugins.web-viewer.action-clear-data-history]
+original=History
+translation=Azray
+
+[plugins.web-viewer.action-clear-data-all]
+original=All web viewer data
+translation=Akk isefka n umeskan n Web
+
+[plugins.web-viewer.action-clear-data-all-desc]
+original=Removes all of the above as well as local storage and active sessions.
+translation=Ad yekkes akk ayen yellan ufella, akked usekles adigan d tiɣimitin urmidin.
+
+[plugins.web-viewer.label-new-web-viewer]
+original=New web viewer
+translation=Ameskan amaynut n Web
+
+[plugins.web-viewer.label-fail-to-load]
+original=Unable to load site.
+translation=D awezɣi asali n usmel.
+
+[plugins.web-viewer.label-fail-to-load-desc]
+original=Make sure you have the correct address.
+translation=Ḍmen belli tesɛiḍ tansa tameɣtut.
+
+[plugins.web-viewer.label-search-the-web]
+original=Search the web
+translation=Nadi deg Web
+
+[plugins.web-viewer.label-web-viewer-data]
+original=Web viewer data
+translation=Isefka n umeskan n Web
+
+[plugins.web-viewer.label-clear-data]
+original=Clear web viewer data
+translation=Sfeḍ isefka n umeskan n Web
+
+[plugins.web-viewer.option-open-external-links]
+original=Open external links
+translation=Ldi iseɣwan uffiɣen
+
+[plugins.web-viewer.option-open-external-links-desc]
+original=Open links in Obsidian rather than the system default.
+translation=Ldi iseɣwan deg Obsidian deg umkan n unagraw amezwer.
+
+[plugins.web-viewer.option-homepage]
+original=Homepage
+translation=Asebter agejdan
+
+[plugins.web-viewer.option-homepage-desc]
+original=What page to view when a web viewer is opened
+translation=D acu n usebter ara twaliḍ mi ara yeldi umeskan n Web
+
+[plugins.web-viewer.option-saved-markdown]
+original=Saved page folder
+translation=Akaram n isebtar yettwaḥerzen
+
+[plugins.web-viewer.option-saved-markdown-desc]
+original=Websites saved as markdown will be placed here.
+translation=Ismal Web yettwaḥerzen am markdown ad ttwasersen dagi.
+
+[plugins.web-viewer.option-search-engine]
+original=Search engine
+translation=Amsadday n unadi
+
+[plugins.web-viewer.option-search-engine-desc]
+original=Search engine used when searching from the address bar.
+translation=Amsadday n unadi yettuseqdacen mi ara tnadiḍ seg tfeggagt n tansa.
+
+[plugins.web-viewer.option-search-engine-custom]
+original=Custom search engine
+translation=Amsadday n unadi yettusagenen
+
+[plugins.web-viewer.option-search-engine-custom-desc]
+original=Use %s in place of the query.
+translation=Seqdec %s deg umkan n tuttra.
+
+[plugins.web-viewer.option-search-engine-custom-drop-down]
+original=Custom
+translation=Sagen
+
+[plugins.web-viewer.option-enable-adblock]
+original=Enable ad blocker
+translation=Sermed amsewḥel n udellel
+
+[plugins.web-viewer.option-enable-adblock-desc]
+original=If enabled, the filter lists below will be applied to all web viewer tabs.
+translation=Ma yermed, tibdarin n tistayin ddaw-a ad ttwasnesent ɣef wakk iccaren n umeskan n Web.
+
+[plugins.web-viewer.option-adblock-lists]
+original=Ad blocking rules
+translation=Ilugan n usewḥel n udellel
+
+[plugins.web-viewer.option-adblock-lists-desc]
+original=One ad block list URL per line. Shared by all vaults.
+translation=Yiwen n URL n tebdart n usewḥel n udellel i yal izirig. Yettwabḍa sɣur wakk ikaramen n weḥraz.
+
+[plugins.web-viewer.option-adblock-frequency]
+original=Ad block update frequency
+translation=Asnagar n umucceḍ n usewḥel n udellel
+
+[plugins.web-viewer.option-adblock-frequency-desc]
+original=Days between updating filter lists. 0 indicates disabled. Shared by all vaults.
+translation=Ussan gar imuccḍen n tebdarin n tistayin. 0 yemmal-d yensa. Yettwabḍa sɣur wakk ikaramen n weḥraz.
+
+[plugins.web-viewer.title-clear-data-modal]
+original=Clear web viewer data
+translation=Sfeḍ isefka n umeskan n Web
+
+[plugins.web-viewer.msg-error-extracting-content]
+original=Unexpected error extracting content.
+translation=Tuccḍa ur netturaju ara deg tussfa n ugbur.
+
+[plugins.web-viewer.msg-error-finding-content]
+original=Unable to find content to extract.
+translation=D awezɣi tifin n ugbur i tussfa.
+
+[plugins.canvas.name]
+original=Canvas
+translation=Abeckil
+
+[plugins.canvas.desc]
+original=Arrange and connect notes on an infinite canvas.
+translation=Sers yerna qqen tizmiltin ɣef ubeckil war talast.
+
+[plugins.canvas.action-add-note]
+original=Add note from vault
+translation=Rnu tazmilt seg ukaram n weḥraz
+
+[plugins.canvas.action-add-media]
+original=Add media from vault
+translation=Rnu amedia seg ukaram n weḥraz
+
+[plugins.canvas.action-add-card]
+original=Add card
+translation=Rnu takarḍa
+
+[plugins.canvas.action-add-website]
+original=Add web page
+translation=Rnu asebter Web
+
+[plugins.canvas.action-create-group]
+original=Create group
+translation=Rnu agraw
+
+[plugins.canvas.action-create-with-size]
+original=Create a card with specific size
+translation=Rnu takarḍa s tiddi uzzig
+
+[plugins.canvas.action-convert-to-file]
+original=Convert to file...
+translation=Selket ɣer ufaylu...
+
+[plugins.canvas.action-drag-to-add-note]
+original=Drag to add note from vault
+translation=Zuɣeṛ i wakken ad ternuḍ tazmilt seg ukaram n weḥraz
+
+[plugins.canvas.action-drag-to-add-media]
+original=Drag to add media from vault
+translation=Zuɣeṛ i wakken ad ternuḍ amedia seg ukaram n weḥraz
+
+[plugins.canvas.action-drag-to-add-card]
+original=Drag to add card
+translation=Zuɣeṛ i wakken ad ternuḍ takarḍa
+
+[plugins.canvas.action-edit-label]
+original=Edit label
+translation=Ẓreg tabzimt
+
+[plugins.canvas.action-remove-label]
+original=Remove label
+translation=Kkes tabzimt
+
+[plugins.canvas.action-search-file]
+original=Search for file
+translation=Nadi ɣef ufaylu
+
+[plugins.canvas.action-set-color]
+original=Set color
+translation=Sers ini
+
+[plugins.canvas.action-align]
+original=Align
+translation=Reyyec
+
+[plugins.canvas.action-align-left]
+original=Align left
+translation=Reyyec ɣer zelmeḍ
+
+[plugins.canvas.action-align-center]
+original=Align center
+translation=Reyyec ɣer tlemmast
+
+[plugins.canvas.action-align-right]
+original=Align right
+translation=Reyyec ɣer yeffus
+
+[plugins.canvas.action-align-top]
+original=Align top
+translation=Reyyec ɣer ufella
+
+[plugins.canvas.action-align-middle]
+original=Align middle
+translation=Reyyec ɣer tlemmast
+
+[plugins.canvas.action-align-bottom]
+original=Align bottom
+translation=Reyyec ɣer wadda
+
+[plugins.canvas.action-distribute-horizontal-spacing]
+original=Distribute horizontal spacing
+translation=Zzuzer azilal aglawan
+
+[plugins.canvas.action-distribute-vertical-spacing]
+original=Distribute vertical spacing
+translation=Zzuzer azilal aratak
+
+[plugins.canvas.action-justify-horizontally]
+original=Justify horizontally
+translation=Tarigla s wudem aglawan
+
+[plugins.canvas.action-justify-vertically]
+original=Justify vertically
+translation=Tarigla s wudem aratak
+
+[plugins.canvas.action-arrange-horizontally]
+original=Arrange in a row
+translation=Sers deg yizirig
+
+[plugins.canvas.action-arrange-vertically]
+original=Arrange in a column
+translation=Sers deg tgejdit
+
+[plugins.canvas.action-arrange-grid]
+original=Arrange in a grid
+translation=Sers deg yiẓiki
+
+[plugins.canvas.action-export-png]
+original=Export as image
+translation=Sifeḍ am tugna
+
+[plugins.canvas.action-jump-to-group]
+original=Jump to group
+translation=Ngez ɣer ugraw
+
+[plugins.canvas.action-set-background]
+original=Set background
+translation=Sbadu agilal
+
+[plugins.canvas.action-edit-background]
+original=Edit background
+translation=Ẓreg agilal
+
+[plugins.canvas.action-replace-background]
+original=Replace background
+translation=Semselsi agilal
+
+[plugins.canvas.action-remove-background]
+original=Remove background
+translation=Kkes agilal
+
+[plugins.canvas.label-no-images]
+original=No images found.
+translation=Ulac tugniwin i yettwafan.
+
+[plugins.canvas.label-no-media]
+original=No media found.
+translation=Ulac amedia i yettwafan.
+
+[plugins.canvas.label-export-png-desc]
+original=Export “{{title}}” as a PNG file with the settings below.
+translation=Sifeḍ “{{title}}” am ufaylu PNG s yiɣewwaṛen ddaw-a.
+
+[plugins.canvas.label-export-png-dimensions]
+original=Estimated image dimensions: {{dimensions}}
+translation=Tisektiwin n tugna yettwaṣeḍkḍen: {{dimensions}}
+
+[plugins.canvas.label-distribute]
+original=Distribute
+translation=Zzuzer
+
+[plugins.canvas.label-justify]
+original=Justify
+translation=Tarigla
+
+[plugins.canvas.label-arrange]
+original=Arrange
+translation=Sers
+
+[plugins.canvas.label-always]
+original=Always
+translation=Dima
+
+[plugins.canvas.label-hover]
+original=On hover
+translation=Mi tsɛeddaḍ taḥnaccaṭ
+
+[plugins.canvas.label-never]
+original=Never
+translation=Werǧin
+
+[plugins.canvas.label-no-section-found]
+original=No section found
+translation=Ulac tagezmi i yettwafan
+
+[plugins.canvas.option-wheel-behavior]
+original=Default mouse wheel behavior
+translation=Tikli tamzewert n tjerṛaṛt n tɣerdayt
+
+[plugins.canvas.option-mod-drag-behavior]
+original=Default {{key}} behavior
+translation=Tikli tamzewert n {{key}}
+
+[plugins.canvas.option-show-menu]
+original=Show menu
+translation=Sken amuɣ
+
+[plugins.canvas.option-new-canvas-location]
+original=Default location for new canvas files
+translation=Ideg amezwer i yifuyla imaynuten n ubeckil
+
+[plugins.canvas.option-new-canvas-location-description]
+original=Where newly created canvas files are placed.
+translation=Anda ara ttwasersen yifuyla imaynuten n ubeckil.
+
+[plugins.canvas.option-new-canvas-folder-path]
+original=Folder to create new canvas files in
+translation=Akaram anda ara d-tesnulfuḍ ifuyla imaynuten n ubeckil
+
+[plugins.canvas.option-new-canvas-folder-path-description]
+original=Newly created canvas files will appear under this folder.
+translation=Ifuyla imaynuten n ubeckil ad d-banen ddaw ukaram-a.
+
+[plugins.canvas.option-node-label]
+original=Show card names
+translation=Sken ismawen n tkarḍiwin
+
+[plugins.canvas.option-snap-to-grid]
+original=Snap to grid
+translation=Senteḍ ɣer yiẓiki
+
+[plugins.canvas.option-snap-to-grid-desc]
+original=Snap cards to the background grid when moving and resizing.
+translation=Senteḍ tikarḍiwin ɣer yiẓiki n ugilal mi ara tesmuttiḍ neɣ ara tbeddleḍ tiddi.
+
+[plugins.canvas.option-snap-to-objects]
+original=Snap to objects
+translation=Senteḍ ɣer tɣawsiwin
+
+[plugins.canvas.option-snap-to-objects-desc]
+original=Snap cards to nearby objects when moving and resizing.
+translation=Senteḍ tikarḍiwin ɣer tɣawsiwin tiqribin mi ara tesmuttiḍ neɣ ara tbeddleḍ tiddi.
+
+[plugins.canvas.option-zoom-breakpoint]
+original=Zoom threshold for hiding card content
+translation=Amnaṛ n usemɣer i wuffar n ugbur n tkarḍa
+
+[plugins.canvas.option-zoom-breakpoint-desc]
+original=Lower values will increase performance but hide card content sooner when zooming out.
+translation=Azalen addayen ad snernin tamellit maca ad ffren agbur n tkarḍa s zreb mi ara tsemẓiḍ.
+
+[plugins.canvas.option-export-png-show-logo]
+original=Show logo
+translation=Sken alugu
+
+[plugins.canvas.option-export-png-show-logo-desc]
+original=This will add an Obsidian logo to the bottom left.
+translation=Aya ad yernu logo n Obsidian ɣer wadda ɣef zelmeḍ.
+
+[plugins.canvas.option-export-png-privacy-mode]
+original=Privacy mode
+translation=Askar n tbaḍnit
+
+[plugins.canvas.option-export-png-privacy-mode-desc]
+original=This will obscure any text on your canvas.
+translation=Aya ad yeffer yal aḍris deg ubeckil-ik.
+
+[plugins.canvas.option-export-png-zoom]
+original=Zoom
+translation=Semɣeṛ/Semẓi
+
+[plugins.canvas.option-export-png-zoom-desc]
+original=A higher zoom will generate a higher resolution image.
+translation=Asemɣer afellay ad d-yesnulfu tugna s tbadut tafellayt.
+
+[plugins.canvas.option-export-png-frame]
+original=Viewport
+translation=Annar n tmuɣli
+
+[plugins.canvas.option-export-png-frame-desc]
+original=Choose to render the entire canvas or just the current visible viewport.
+translation=Fren ad d-tsireweḍ abeckil ummid neɣ kan annar n tmuɣli amiran yettbanen.
+
+[plugins.canvas.option-export-png-frame-full]
+original=Full canvas
+translation=Abeckil ummid
+
+[plugins.canvas.option-export-png-frame-viewport]
+original=Viewport only
+translation=Annar n tmuɣli kan
+
+[plugins.canvas.option-background-cover]
+original=Cover
+translation=Taduli
+
+[plugins.canvas.option-background-ratio]
+original=Keep aspect ratio
+translation=Ḥrez assaɣ n tmuɣli
+
+[plugins.canvas.option-background-repeat]
+original=Repeat
+translation=Ales
+
+[plugins.canvas.action-new-canvas]
+original=New canvas
+translation=Abeckil amaynut
+
+[plugins.canvas.action-duplicate]
+original=Duplicate
+translation=Sleg
+
+[plugins.canvas.action-remove]
+original=Remove
+translation=Kkes
+
+[plugins.canvas.action-narrow-heading]
+original=Narrow to heading...
+translation=Fneẓ ɣer tsenṭit...
+
+[plugins.canvas.action-narrow-block]
+original=Narrow to block...
+translation=Fneẓ ɣer yiḥder...
+
+[plugins.canvas.action-narrow-bases-view]
+original=Pin view...
+translation=Sbeḍ taskant...
+
+[plugins.canvas.action-swap-file]
+original=Swap file...
+translation=Semmeskel afaylu...
+
+[plugins.canvas.action-change-url]
+original=Change URL...
+translation=Beddel URL...
+
+[plugins.canvas.action-zoom-to-fit]
+original=Zoom to fit
+translation=Zoom i usezgi
+
+[plugins.canvas.action-zoom-to-selection]
+original=Zoom to selection
+translation=Zoom ɣer tefrayt
+
+[plugins.canvas.action-reload-page]
+original=Reload page
+translation=Ales asali n usebter
+
+[plugins.canvas.action-follow-connection]
+original=Follow connection
+translation=Ḍfaṛ tuqqna
+
+[plugins.canvas.command-create-new-canvas]
+original=Create new canvas
+translation=Snulfu-d abecki amaynut
+
+[plugins.canvas.command-convert-to-file]
+original=Convert to file...
+translation=Selket ɣer ufaylu...
+
+[plugins.canvas.instruction-narrow-heading]
+original=to embed heading
+translation=i useddu n tsenṭit
+
+[plugins.canvas.instruction-narrow-block]
+original=to embed block
+translation=i useddu n yiḥder
+
+[plugins.canvas.instruction-jump-to-group]
+original=to navigate to group
+translation=i tunigin ɣer ugraw
+
+[plugins.canvas.prompt-to-narrow]
+original=Type to find file, heading, or block
+translation=Aru i wakken ad tafeḍ afaylu, tasenṭit, neɣ iḥder
+
+[plugins.canvas.label-enter-url]
+original=Enter URL
+translation=Sekcem URL
+
+[plugins.canvas.label-empty-embed]
+original=“{{linktext}}” could not be found.
+translation=“{{linktext}}” ur yettwafa ara.
+
+[plugins.canvas.prompt-add-text]
+original=Add text...
+translation=Rnu aḍris...
+
+[plugins.canvas.prompt-start-search]
+original=Type to search...
+translation=Aru i wakken ad tnadiḍ...
+
+[plugins.canvas.label-canvas-help]
+original=Canvas help
+translation=Tallalt n ubeckil
+
+[plugins.canvas.label-canvas-settings]
+original=Canvas settings
+translation=Iɣewwaṛen n ubeckil
+
+[plugins.canvas.label-no-narrow]
+original=Show entire file
+translation=Sken afaylu ummid
+
+[plugins.canvas.label-show-default-view]
+original=Show default view
+translation=Sken taskant tamzewert
+
+[plugins.canvas.label-readonly]
+original=Read-only
+translation=Taɣuri kan
+
+[plugins.canvas.label-disable-readonly]
+original=Disable read-only
+translation=Ssens taɣuri kan
+
+[plugins.canvas.label-pan]
+original=Pan
+translation=Azuɣer
+
+[plugins.canvas.label-pan-horizontal]
+original=Pan horizontally
+translation=Azuɣer aglawan
+
+[plugins.canvas.label-zoom]
+original=Zoom
+translation=Zoom
+
+[plugins.canvas.label-select-all]
+original=Select all
+translation=Fren akk
+
+[plugins.canvas.label-add-remove-selection]
+original=Add to / remove from selection
+translation=Rnu ɣer / kkes seg tefrayt
+
+[plugins.canvas.label-clone-card]
+original=Clone card
+translation=Sleg takarḍa
+
+[plugins.canvas.label-constrain-movement-axis]
+original=Constrain card movement to axis
+translation=Ḥreṣ amussu n tkarḍa ɣer ugellus
+
+[plugins.canvas.label-disable-drag-snapping]
+original=Disable snapping while dragging
+translation=Ssens aṭṭaf mi ara tzuɣuṛeḍ
+
+[plugins.canvas.label-remove-card]
+original=Remove card
+translation=Kkes takarḍa
+
+[plugins.canvas.label-drag-from-below]
+original=Drag from below or double click
+translation=Zuɣeṛ seg wadda neɣ sit snat n tikkal
+
+[plugins.canvas.label-longpress]
+original=Touch and hold to add / move / select
+translation=Sḍes yerna ṭṭef i wernuy / asmutti / tafrayt
+
+[plugins.canvas.label-drag-pan]
+original=Drag to pan
+translation=Zuɣeṛ i tmuɣli
+
+[plugins.canvas.label-pinch-zoom]
+original=Pinch to zoom
+translation=Qmeḍ i usemɣer
+
+[plugins.canvas.label-space-drag-pan]
+original=Space + Drag to pan
+translation=Tallunt + Zuɣeṛ i tmuɣli
+
+[plugins.canvas.label-scroll-to-zoom]
+original=Scroll to zoom
+translation=Drurem i usemɣer
+
+[plugins.canvas.label-untitled-group]
+original=Untitled group
+translation=Agraw war azwel
+
+[plugins.canvas.label-line-direction]
+original=Line direction
+translation=Tanila n yizirig
+
+[plugins.canvas.label-nondirectional]
+original=Nondirectional
+translation=War tanila
+
+[plugins.canvas.label-unidirectional]
+original=Unidirectional
+translation=Tanilayant
+
+[plugins.canvas.label-bidirectional]
+original=Bidirectional
+translation=Tasnilant
+
+[plugins.canvas.label-image]
+original=Image
+translation=Tugna
+
+[plugins.canvas.label-style]
+original=Style
+translation=Aɣanib
+
+[plugins.canvas.msg-no-groups-found]
+original=No groups found
+translation=Ulac igrawen i yettwafan
+
+[plugins.canvas.msg-export-failed-empty-canvas]
+original=Cannot export an empty canvas
+translation=D awezɣi asifeḍ n ubeckil ilem
+
+[plugins.canvas.msg-updating-links]
+original=Canvas detected file renames affecting {{count}} canvas file, updating...
+translation=Abeckil yufa-d isnifelen n yismawen n yifuyla i yettḥazazen {{count}} ufaylu n ubeckil, amucceḍ tura...
+
+[plugins.canvas.msg-updating-links_plural]
+original=Canvas detected file renames affecting {{count}} canvas files, updating...
+translation=Abeckil yufa-d isnifelen n yismawen n yifuyla i yettḥazazen {{count}} n yifuyla n ubeckil, amucceḍ tura...
+
+[plugins.canvas.msg-updated-links]
+original=Canvas updated {{count}} embed card
+translation=Abeckil imucceḍ {{count}} n tkarḍa yettwaseddun
+
+[plugins.canvas.msg-updated-links_plural]
+original=Canvas updated {{count}} embed cards
+translation=Abeckil imucceḍ {{count}} n tkarḍiwin yettwaseddun
+
+[plugins.bases.name]
+original=Bases
+translation=Taffiwin
+
+[plugins.bases.desc]
+original=Create custom views that let you edit, sort, and filter files using their properties.
+translation=Snulfu-d tiskniwin yettusagenen i k-yettaken tagnit ad tẓergeḍ, ad tefreneḍ, yerna ad testayḍ ifuyla s useqdec n yiraten-nsen.
+
+[plugins.bases.action-new-base]
+original=New base
+translation=Taffa tamaynut
+
+[plugins.bases.action-add-property]
+original=Add "{{name}}" property
+translation=Rnu arat "{{name}}"
+
+[plugins.bases.action-add-summary]
+original=Add "{{name}}" summary
+translation=Rnu agzul "{{name}}"
+
+[plugins.bases.action-add-formula]
+original=Add formula
+translation=Rnu talɣa
+
+[plugins.bases.action-hide-all]
+original=Hide all
+translation=Ffer akk
+
+[plugins.bases.action-toggle-visibility]
+original=Toggle visibility
+translation=Qluqel timeẓriwti
+
+[plugins.bases.action-delete-formula]
+original=Delete formula
+translation=Kkes talɣa
+
+[plugins.bases.action-set-default-view]
+original=Default view
+translation=Taskant tamzewert
+
+[plugins.bases.action-duplicate-view]
+original=Duplicate view
+translation=Sleg taskant
+
+[plugins.bases.action-delete-view]
+original=Delete view
+translation=Kkes taskant
+
+[plugins.bases.action-delete-summary]
+original=Delete summary
+translation=Kkes agzul
+
+[plugins.bases.action-export-c-s-v]
+original=Export CSV...
+translation=Sifeḍ ɣer CSV...
+
+[plugins.bases.command-create-new]
+original=Create new base
+translation=Snulfu-d taffa tamaynut
+
+[plugins.bases.command-insert-new]
+original=Insert new base
+translation=Ger taffa tamaynut
+
+[plugins.bases.command-copy-table]
+original=Copy table to clipboard
+translation=Nɣel tafelwit ɣer tecfawit
+
+[plugins.bases.command-change-view]
+original=Switch view...
+translation=Beddel taskant...
+
+[plugins.bases.command-add-view]
+original=Add view
+translation=Rnu taskant
+
+[plugins.bases.command-add-item]
+original=Add item
+translation=Rnu aferdis
+
+[plugins.bases.button-add-view]
+original=Add view
+translation=Rnu taskant
+
+[plugins.bases.button-add-filter]
+original=Add filter
+translation=Rnu tastayt
+
+[plugins.bases.button-add-filter-group]
+original=Add filter group
+translation=Rnu agraw n tistayin
+
+[plugins.bases.button-show-all]
+original=Show all
+translation=Sken akk
+
+[plugins.bases.button-show-all-count]
+original=Show all ({{count}})
+translation=Sken akk ({{count}})
+
+[plugins.bases.button-add-summary]
+original=Add summary
+translation=Rnu agzul 
+
+[plugins.bases.button-hide-summary]
+original=Hide summary
+translation=Ffer agzul 
+
+[plugins.bases.label-all-views]
+original=All views
+translation=Akk tiskanayin
+
+[plugins.bases.label-current-view]
+original=This view
+translation=Taskant-a
+
+[plugins.bases.placeholder-search-property]
+original=Find or create...
+translation=Af-d neɣ snulfu-d...
+
+[plugins.bases.label-computed-properties]
+original=Computed properties
+translation=Iraten yettwasiḍnen
+
+[plugins.bases.label-property-type]
+original=Property type
+translation=Tawsit n urat 
+
+[plugins.bases.label-hide-property]
+original=Hide property
+translation=Ffer arat 
+
+[plugins.bases.label-show-property]
+original=Show property
+translation=Sken arat 
+
+[plugins.bases.label-edit-property]
+original=Edit property
+translation=Ẓreg arat 
+
+[plugins.bases.title-edit-property]
+original=Edit {{name}}
+translation=Ẓreg {{name}}
+
+[plugins.bases.label-configure-view]
+original=Configure view
+translation=Swel taskant 
+
+[plugins.bases.label-view-layout]
+original=Layout
+translation=Aɣawas 
+
+[plugins.bases.label-global-filters]
+original=Global filters
+translation=Tistayin imuta
+
+[plugins.bases.label-view-filters]
+original=View filters
+translation=Tistayin n teskant 
+
+[plugins.bases.label-view-name]
+original=View name
+translation=Isem n teskant
+
+[plugins.bases.label-default-view]
+original=View
+translation=Taskant
+
+[plugins.bases.label-view-type-table]
+original=Table
+translation=Tafelwit 
+
+[plugins.bases.label-display-name]
+original=Display name
+translation=Isem n ubeqqeḍ
+
+[plugins.bases.label-summary-name]
+original=Summary name
+translation=Isem n ugzul 
+
+[plugins.bases.label-formula]
+original=Formula
+translation=Talɣa
+
+[plugins.bases.label-views]
+original=Views
+translation=Tiskniwin
+
+[plugins.bases.label-sort]
+original=Sort
+translation=Smizzwer 
+
+[plugins.bases.label-filter]
+original=Filter
+translation=Tastayt 
+
+[plugins.bases.label-search]
+original=Search
+translation=Anadi 
+
+[plugins.bases.label-properties]
+original=Properties
+translation=Iraten 
+
+[plugins.bases.label-new-item]
+original=New
+translation=Amaynut 
+
+[plugins.bases.label-search-results]
+original=Showing {{count}}
+translation=Yeskanay-d {{count}}
+
+[plugins.bases.label-new-item-template-file]
+original=New item template file
+translation=Afaylu n tmudemt n uferdis amaynut 
+
+[plugins.bases.label-new-item-folder]
+original=New item folder
+translation=Akaram n uferdis amaynut 
+
+[plugins.bases.label-any-of-the-following]
+original=Any of the following are true
+translation=Kra seg wid-a d tidet
+
+[plugins.bases.label-all-the-following]
+original=All the following are true
+translation=Akk wid-a d tidet
+
+[plugins.bases.label-none-of-the-following]
+original=None of the following are true
+translation=Ula d yiwen seg wid-a d tidet
+
+[plugins.bases.label-where]
+original=where
+translation=anda
+
+[plugins.bases.label-or]
+original=or
+translation=neɣ
+
+[plugins.bases.label-and]
+original=and
+translation=d
+
+[plugins.bases.label-property-key]
+original=Property
+translation=Arat 
+
+[plugins.bases.label-untitled-property]
+original=Untitled
+translation=War azwel
+
+[plugins.bases.label-file-prop-file]
+original=file
+translation=afaylu 
+
+[plugins.bases.label-file-prop-name]
+original=file name
+translation=isem n ufaylu 
+
+[plugins.bases.label-file-prop-base-name]
+original=file base name
+translation=isem n uzadur n ufaylu 
+
+[plugins.bases.label-file-prop-full-name]
+original=file full name
+translation=isem ummid n ufaylu 
+
+[plugins.bases.label-file-prop-path]
+original=file path
+translation=abrid n ufaylu 
+
+[plugins.bases.label-file-prop-folder]
+original=folder
+translation=akaram 
+
+[plugins.bases.label-file-prop-ext]
+original=file extension
+translation=asiɣzef n ufaylu 
+
+[plugins.bases.label-file-prop-ctime]
+original=created time
+translation=akud n wesnulfu
+
+[plugins.bases.label-file-prop-mtime]
+original=modified time
+translation=akud n ubeddel
+
+[plugins.bases.label-file-prop-size]
+original=file size
+translation=tiddi n ufaylu
+
+[plugins.bases.label-file-prop-backlinks]
+original=file backlinks
+translation=iseɣwan ikcamen n ufaylu 
+
+[plugins.bases.label-file-prop-links]
+original=file links
+translation=iseɣwan n ufaylu 
+
+[plugins.bases.label-file-prop-embeds]
+original=file embeds
+translation=isedduyen n ufaylu 
+
+[plugins.bases.label-file-prop-tags]
+original=file tags
+translation=ticraḍ n ufaylu 
+
+[plugins.bases.label-add-sort]
+original=Add sort
+translation=Rnu amizzwer 
+
+[plugins.bases.label-group-by]
+original=Group by
+translation=Ssegrew s 
+
+[plugins.bases.label-sort-by]
+original=Sort by
+translation=Smizzwer s 
+
+[plugins.bases.label-limit]
+original=Limit number of results
+translation=Eg talast i wemḍan n yigmaḍ
+
+[plugins.bases.label-sort-a-z]
+original=A → Z
+translation=A → Z
+
+[plugins.bases.label-sort-z-a]
+original=Z → A
+translation=Z → A
+
+[plugins.bases.label-sort-old-new]
+original=Old to new
+translation=Aqbur ar umaynut
+
+[plugins.bases.label-sort-new-old]
+original=New to old
+translation=Amaynut ar uqbur
+
+[plugins.bases.label-sort01]
+original=0 → 1
+translation=0 → 1
+
+[plugins.bases.label-sort10]
+original=1 → 0
+translation=1 → 0
+
+[plugins.bases.msg-invalid-view-name]
+original=View name cannot contain: 
+translation=Isem n teskant ur yezmir ara ad yesɛu: 
+
+[plugins.bases.msg-duplicate-view-name]
+original=View name already exists.
+translation=Isem n teskant yella yakan.
+
+[plugins.bases.msg-empty-view-name]
+original=View name cannot be empty.
+translation=Isem n teskant ur yezmir ara ad yili d ilem.
+
+[plugins.bases.msg-filter-simple-unavailable]
+original=This filter cannot be represented by the simple filter builder.
+translation=Tastayt-a ur tezmir ara ad tettwagensess sɣur umesnulfu aḥerfi n tistayin.
+
+[plugins.bases.msg-filter-cannot-parse]
+original=Filter cannot be parsed. Basic filter builder cannot be used.
+translation=Tastayt ur tezmir ara ad tettwasleḍ. Amesnulfu n tistayin n uzadur ur yezmir ara ad yettuseqdec. 
+
+[plugins.bases.msg-error-invalid-properties-section]
+original=Invalid properties configuration.
+translation=Tawila n yiraten d tarmeɣtut. 
+
+[plugins.bases.msg-error-invalid-property-config]
+original=Invalid property config for "{{ name }}".
+translation=Tawila n urat d tarmeɣtut i "{{ name }}". 
+
+[plugins.bases.msg-error-register-view]
+original=Unable to add new Bases view "{{ viewId }}". A view with this ID already exists.
+translation=Ur yezmir ara ad yernu taskant tamaynut n Teffiwin "{{ viewId }}". Taskant s usulay-a tella yakan. 
+
+[plugins.bases.msg-error-unable-to-parse]
+original=Unable to parse your base file:
+translation=Ur yezmir ara ad yesleḍ afaylu-k n taffa: 
+
+[plugins.bases.msg-error-view-not-found]
+original=View "{{ view }}" not found
+translation=Taskant "{{ view }}" ur tettwafa ara
+
+[plugins.bases.msg-error-unknown-view-type]
+original=Unknown view type: {{ viewtype }}
+translation=Tawsit n teskant ur tettwassen ara: {{ viewtype }} 
+
+[plugins.bases.msg-error-view-type]
+original=Views must be an array
+translation=Tiskanayin ilaq ad ilint d isirwen 
+
+[plugins.bases.msg-error-display-values]
+original=Display values must be strings. Value for property {{ key }} is not.
+translation=Izalen n ubeqqeḍ ilaq ad ilin d izurar. Azal i urat {{ key }} mačči d azrar.
+
+[plugins.bases.msg-error-must-be-a-type]
+original="{{ key }}" must be a {{ type }}
+translation="{{ key }}" ilaq ad yili d {{ type }}
+
+[plugins.bases.msg-error-filter-type]
+original="filters" must be a string or an object
+translation="tistayin" ilaq ad ilint d azrar neɣ d taɣawsa 
+
+[plugins.bases.msg-error-filter-must-be-array]
+original="{{ conjunction }}" filter must be an array
+translation=Tastayt "{{ conjunction }}" ilaq ad tili d isirew 
+
+[plugins.bases.msg-error-filter-allowed-keys]
+original="filters" may only have one of an "and", "or", or "not" keys.
+translation="tistayin" zemrent ad sɛunt kan yiwet seg tsura "and", "or", neɣ "not".
+
+[plugins.bases.msg-error-filter-failed-to-evaluate]
+original=Failed to evaluate a filter: {{ message }}
+translation=Yecceḍ uskazal n testayt: {{ message }}
+
+[plugins.bases.msg-error-formula-values]
+original=Formula values must be strings. Value for property {{ key }} is not.
+translation=Izalen n telɣa ilaq ad ilin d izurar. Azal i urat {{ key }} mačči d azrar.
+
+[plugins.bases.msg-error-computed-failed-to-compute]
+original=Failed to compute value of property "{{ key }}": {{ message }}
+translation=Yecceḍ usiḍen n wazal n urat "{{ key }}": {{ message }}
+
+[plugins.bases.msg-error-invalid-query-format]
+original=Query is an invalid format. It should be a YAML object.
+translation=Tuttra tesɛa amasal ur neɣbil ara. Ilaq ad tili d taɣawsa YAML.
+
+[plugins.bases.msg-error-view-invalid-format]
+original="view" items must be a YAML object, however item {{ index }} is not
+translation=Iferdisen n "taskant" ilaq ad ilin d taɣawsa YAML, maca aferdis {{ index }} ur yelli ara.
+
+[plugins.bases.msg-error-view-name-invalid]
+original=Missing or invalid "name" in view {{ index }}
+translation=Isem ixuṣ neɣ ur yeɣbil ara deg teskant {{ index }}
+
+[plugins.bases.msg-error-view-missing-required-key]
+original="{{ key }}" is required in view "{{ viewName }}"
+translation="{{ key }}" yettusra deg teskant "{{ viewName }}"
+
+[plugins.bases.msg-error-view-incorrect-type]
+original="{{ key }}" must be a {{ type }} in view "{{ viewName }}"
+translation="{{ key }}" ilaq ad yili d {{ type }} deg teskant "{{ viewName }}"
+
+[plugins.bases.msg-error-view-incorrect-value-type]
+original="{{ key }}" values must all be of type {{ type }} in view "{{ viewName }}"
+translation=Izalen n "{{ key }}" ilaq merra ad ilin n tewsit {{ type }} deg teskant "{{ viewName }}"
+
+[plugins.bases.msg-error-view-parsing-filters]
+original=Unable to parse filters in view "{{ viewName }}": {{ message }}
+translation=D awezɣi tasleṭ n tistayin deg teskant "{{ viewName }}": {{ message }}
+
+[plugins.bases.msg-error-infinite-loop]
+original=Infinite loop detected in formula
+translation=Tineddict war taggara tettwaf deg telɣa
+
+[plugins.bases.msg-error-invalid-property]
+original=Invalid property
+translation=Arat ur neɣbil ara
+
+[plugins.bases.msg-new-item-filtered]
+original=This note will be filtered out because it doesn't match your criteria
+translation=Tazmilt-a ad tettwastixeṛ acku ur temṣada ara d tisefrayin-ik·im
+
+[plugins.bases.placeholder-filter-advanced-mode]
+original=Advanced filter
+translation=Tastayt talqayt
+
+[plugins.bases.placeholder-limit]
+original=e.g. 10
+translation=amedya. 10
+
+[plugins.bases.tooltip-filter-advanced-mode]
+original=Advanced filter
+translation=Tastayt talqayt
+
+[plugins.bases.tooltip-filter-simple-mode]
+original=Simple filter
+translation=Tastayt taḥerfit
+
+[plugins.bases.tooltip-remove-filter]
+original=Remove filter
+translation=Kkes tastayt
+
+[plugins.bases.label-group-key-none]
+original=None
+translation=Ulac
+
+[plugins.bases.list.name]
+original=List
+translation=Tabdart
+
+[plugins.bases.list.label-markers]
+original=Markers
+translation=Imcaccalen
+
+[plugins.bases.list.label-indent-properties]
+original=Indent properties
+translation=Iraten n usiẓi
+
+[plugins.bases.list.label-property-separator]
+original=Property separator
+translation=Anabraz n yiraten
+
+[plugins.bases.list.option-bullet]
+original=Bullet
+translation=Tililect
+
+[plugins.bases.list.option-number]
+original=Number
+translation=Amḍan
+
+[plugins.bases.list.option-none]
+original=None
+translation=Ulac
+
+[plugins.bases.cards.name]
+original=Cards
+translation=Tikarḍiwin
+
+[plugins.bases.cards.label-card-size]
+original=Card size
+translation=Tiddi n tkarḍa
+
+[plugins.bases.cards.label-image-property]
+original=Image property
+translation=Arat n tugna
+
+[plugins.bases.cards.label-image-fit]
+original=Image fit
+translation=Asezgi n tugna
+
+[plugins.bases.cards.option-image-fit-cover]
+original=Cover
+translation=Taduli
+
+[plugins.bases.cards.option-image-fit-contain]
+original=Contain
+translation=Eṭṭef
+
+[plugins.bases.cards.label-image-aspect-ratio]
+original=Image aspect ratio
+translation=Assaɣ n tmuɣli n tugna
+
+[plugins.bases.table.name]
+original=Table
+translation=Tafelwit
+
+[plugins.bases.table.action-hide-column]
+original=Hide column
+translation=Ffer tigejdit
+
+[plugins.bases.table.action-edit-property]
+original=Edit property...
+translation=Ẓreg arat...
+
+[plugins.bases.table.action-edit-formula]
+original=Edit formula...
+translation=Ẓreg talɣa...
+
+[plugins.bases.table.action-sort-default]
+original=Clear sort
+translation=Sfeḍ amizzwer
+
+[plugins.bases.table.action-sort-a-z]
+original=Sort A → Z
+translation=Wezzer A → Z
+
+[plugins.bases.table.action-sort-z-a]
+original=Sort Z → A
+translation=Smizzwer Z → A
+
+[plugins.bases.table.label-row-height]
+original=Row height
+translation=Tiɣzi n yizirig
+
+[plugins.bases.table.option-short]
+original=Short
+translation=Awezlan
+
+[plugins.bases.table.option-medium]
+original=Medium
+translation=Alemmas
+
+[plugins.bases.table.option-tall]
+original=Tall
+translation=Aɣezfan
+
+[plugins.bases.table.option-extra-tall]
+original=Extra tall
+translation=Aɣezfan aṭas
+
+[plugins.bases.table.action-select-summary]
+original=Summarize...
+translation=Gzel...
+
+[plugins.bases.table.action-group-by]
+original=Group by this property
+translation=Ssegrew s urat-a
+
+[plugins.bases.table.action-clear-selection]
+original=Clear values
+translation=Sfeḍ izalen
+
+[plugins.bases.table.label-summary]
+original=Summary
+translation=Agzul
+
+[formulas.msg-error-parse-formula]
+original=Failed to parse formula "{{ formula }}"
+translation=Yecceḍ wesleḍ n telɣa "{{ formula }}"
+
+[formulas.msg-error-invalid-function]
+original=Cannot find function "{{ function }}"
+translation=Ur yezmir ara ad yaf tasɣent "{{ function }}"
+
+[formulas.msg-error-invalid-instance-function]
+original=Cannot find function "{{ function }}" on type {{ type }}
+translation=Ur yezmir ara ad yaf tasɣent "{{ function }}" ɣef tewsit {{ type }}
+
+[formulas.msg-error-not-enough-arguments]
+original=Cannot call function "{{ function }}", not enough arguments.
+translation=Ur yezmir ara ad isiwel i tesɣent "{{ function }}", xuṣṣen ifukal.
+
+[formulas.msg-error-too-many-arguments]
+original=Cannot call function "{{ function }}", too many arguments.
+translation=Ur yezmir ara ad isiwel i tesɣent "{{ function }}", aṭas n ifukal.
+
+[formulas.msg-error-type-error]
+original=Type error in "{{ function }}", parameter "{{ parameter }}". Expected {{ expected }}, given {{ given }}.
+translation=Tuccḍa n tewsit deg "{{ function }}", aɣewwaṛ "{{ parameter }}". Yetturaǧu {{ expected }}, yettunefk-d {{ given }}.
+
+[formulas.msg-error-invalid-array-access]
+original=Cannot access index "{{ index }}" of non-array value
+translation=Ur yezmir ara ad yekcem ɣer umatar "{{ index }}" n wazal ur nelli ara d asirew
+
+[formulas.msg-error-invalid-object-access]
+original=Cannot find "{{ index }}" on type {{ type }}
+translation=Ur yezmir ara ad yaf "{{ index }}" ɣef tewsit {{ type }}
+
+[pdf.action-highlight-all]
+original=Highlight all
+translation=Sebrureq akk
+
+[pdf.action-match-diacritics]
+original=Match diacritics
+translation=Mṣada d yizmulen n ususru
+
+[pdf.action-whole-words]
+original=Whole words
+translation=Awalen ummiden
+
+[pdf.action-show-thumbnails]
+original=Thumbnails
+translation=Tugniwin tiqmaḍin
+
+[pdf.action-show-outline]
+original=Table of contents
+translation=Tafelwit n igburen
+
+[pdf.action-reveal-in-outline]
+original=Reveal page in table of contents
+translation=Sken asebter deg tfelwit n ugbur
+
+[pdf.action-toggle-sidebar]
+original=Toggle sidebar
+translation=Qluqel agalis adisan
+
+[pdf.action-previous-page]
+original=Previous page
+translation=Asebter uqbel
+
+[pdf.action-next-page]
+original=Next page
+translation=Asebter uḍfir
+
+[pdf.action-fit-width]
+original=Fit width
+translation=Sezg tehri
+
+[pdf.action-fit-height]
+original=Fit height
+translation=Sezg tiɣzi
+
+[pdf.action-save-p-d-f-location]
+original=Save current position in document
+translation=Sekles ideg amiran deg yisemli
+
+[pdf.action-copy-annotation]
+original=Copy annotation
+translation=Nɣel awennit
+
+[pdf.action-copy-quote]
+original=Copy as quote
+translation=Nɣel am ubdar
+
+[pdf.action-copy-selection-link]
+original=Copy link to selection
+translation=Nɣel aseɣwen ɣer tefrayt
+
+[pdf.action-copy-annot-link]
+original=Copy link to annotation
+translation=Nɣel aseɣwen ɣer uwennit
+
+[pdf.action-copy-section-link]
+original=Copy link to section
+translation=Nɣel aseɣwen ɣer tgezmi
+
+[pdf.action-copy-section-link-title]
+original=Copy link to “{{title}}”
+translation=Nɣel aseɣwen ɣer “{{title}}”
+
+[pdf.action-copy-page-link]
+original=Copy link to page {{page}}
+translation=Nɣel aseɣwen ɣer usebter {{page}}
+
+[pdf.msg-max-search-results]
+original={{current}} of over {{limit}} matches
+translation={{current}} ɣef wugar n {{limit}} n yimṣadan
+
+[pdf.msg-search-count]
+original={{current}} of {{total}} match
+translation={{current}} ɣef {{total}} umṣada
+
+[pdf.msg-search-count_plural]
+original={{current}} of {{total}} matches
+translation={{current}} ɣef {{total}} n yimṣadan
+
+[pdf.msg-password-protected]
+original=This PDF is password protected
+translation=Afaylu-a PDF yettummesten s wawal n uɛeddi
+
+[pdf.msg-invalid-password]
+original=Invalid password
+translation=Awal n uɛeddi d armeɣtu
+
+[pdf.msg-enter-password]
+original=Enter the password below
+translation=Sekcem awal n uɛeddi ddaw-a
+
+[pdf.label-of-pages]
+original=of {{count}}
+translation=seg {{count}}
+
+[pdf.label-page-of-pages]
+original=({{current}} of {{count}})
+translation=({{current}} seg {{count}})
+
+[pdf.label-spread-single]
+original=Single page
+translation=Asebter asuf
+
+[pdf.label-spread-odd]
+original=Two-page (odd)
+translation=Snat isebtar (aryugan)
+
+[pdf.label-spread-even]
+original=Two-page (even)
+translation=Snat isebtar (ayugan)
+
+[pdf.tooltip-sidebar-options]
+original=Sidebar options
+translation=Tixtiṛiyin n ugalis adisan
+
+[pdf.tooltip-display-options]
+original=Display options
+translation=Tixtiṛiyin n ubeqqeḍ
+
+[pdf.label-adapt-to-theme]
+original=Adapt to theme
+translation=Sezg ɣer usentel
+
+[pdf.label-page]
+original=page {{page}}
+translation=asebter {{page}}
+
+[pdf.page_landmark]
+original=Page {{page}}
+translation=Asebter {{page}}
+
+[pdf.thumb_page_title]
+original=Page {{page}}
+translation=Asebter {{page}}
+
+[pdf.thumb_page_canvas]
+original=Page {{page}}
+translation=Asebter {{page}}
+
+[pdf.text_annotation_type]
+original=[{{type}} Annotation]
+translation=[Awennit {{type}}]
+
+[pdf.annotation_date_string]
+original={{date}}, {{time}}
+translation={{date}}, {{time}}
+
+[properties.types.option-multitext]
+original=List
+translation=Tabdart
+
+[properties.types.option-unknown]
+original=Unknown
+translation=Ur yettwassen ara
+
+[properties.types.option-text]
+original=Text
+translation=Aḍris
+
+[properties.types.option-aliases]
+original=Aliases
+translation=Tizaẓluyin
+
+[properties.types.option-tags]
+original=Tags
+translation=Ticraḍ
+
+[properties.types.option-folder]
+original=Folder
+translation=Akaram
+
+[properties.types.option-file]
+original=File
+translation=Afaylu
+
+[properties.types.option-property-name]
+original=Property
+translation=Arat
+
+[properties.types.option-date]
+original=Date
+translation=Azemz
+
+[properties.types.option-datetime]
+original=Date & time
+translation=Azemz d wakud
+
+[properties.types.option-number]
+original=Number
+translation=Amḍan
+
+[properties.types.option-checkbox]
+original=Checkbox
+translation=Tanaka n ufran
+
+[properties.value-suggestion.key-link-note]
+original=Type [[
+translation=Aru [[
+
+[properties.value-suggestion.instruction-link-note]
+original=to link note
+translation=i tuqqna n tezmilt
+
+[properties.value-suggestion.instruction-dismiss]
+original=to dismiss
+translation=agi
+
+[properties.option-property-type]
+original=Property type
+translation=Tawsit n urat
+
+[properties.option-sort]
+original=Sort
+translation=Smizzwer
+
+[properties.msg-empty-property-name]
+original=Property name cannot be empty.
+translation=Isem n urat ur yezmir ara ad yili d ilem.
+
+[properties.msg-duplicate-property-name]
+original=Property already exists
+translation=Arat yella yakan
+
+[properties.msg-invalid-tag]
+original=Invalid tag name
+translation=Isem n tecreṭ ur yeɣbil ara
+
+[properties.msg-invalid-number]
+original=Invalid number
+translation=Amḍan armeɣtu
+
+[properties.msg-invalid-properties]
+original=Failed to read properties.
+translation=Tecceḍ tɣuri n yiraten.
+
+[properties.label-no-value]
+original=Empty
+translation=Ilem
+
+[properties.label-heading]
+original=Properties
+translation=Iraten
+
+[properties.label-invalid-heading]
+original=Invalid properties
+translation=Iraten d irmeɣta
+
+[properties.label-show-source]
+original=Show source
+translation=Sken aɣbalu
+
+[properties.label-invalid-yaml-marker]
+original=Syntax error. Your frontmatter is invalid.
+translation=Tuccḍa n tseddast. Tanga tamenzut-ik·im d tarmeɣtut.
+
+[properties.label-add-property-button]
+original=Add property
+translation=Rnu arat
+
+[properties.label-type-mismatch-warning]
+original=Type mismatch, expected {{type}}
+translation=Tawsit ur temṣada ara, yetturaǧu {{type}}
+
+[properties.label-type-mismatch-warning-generic]
+original=Type mismatch
+translation=Tawsit ur temṣada ara
+
+[properties.label-change-property-type]
+original=Display as {{type}}?
+translation=Beqqeḍ am {{type}}?
+
+[properties.label-change-property-type-desc]
+original=Your {{oldType}} data is not compatible. It will be adapted to fit the new format.
+translation=Isefka-k·m {{oldType}} ur mṣadan ara. Ad ttusizgen i wakken ad mwatan d umasal amaynut.
+
+[table.label-column]
+original=Column
+translation=Tigejdit
+
+[table.label-row]
+original=Row
+translation=Izirig
+
+[table.action-row-after]
+original=Add row below
+translation=Rnu izirig ddaw-a
+
+[table.action-column-after]
+original=Add column to the right
+translation=Rnu tigejdit ɣer yeffus
+
+[table.action-row-before]
+original=Add row above
+translation=Rnu izirig sennig
+
+[table.action-row-up]
+original=Move row up
+translation=Sali izirig
+
+[table.action-row-down]
+original=Move row down
+translation=Sader izirig
+
+[table.action-column-before]
+original=Add column to the left
+translation=Rnu tigejdit ɣer zelmeḍ
+
+[table.action-column-left]
+original=Move column left
+translation=Smutti tigejdit ɣer zelmeḍ
+
+[table.action-column-right]
+original=Move column right
+translation=Smutti tigejdit ɣer yeffus
+
+[table.action-duplicate-row]
+original=Duplicate row
+translation=Sleg izirig
+
+[table.action-duplicate-column]
+original=Duplicate column
+translation=Sleg tigejdit
+
+[table.action-delete-row]
+original=Delete row
+translation=Kkes izirig
+
+[table.action-delete-column]
+original=Delete column
+translation=Kkes tigejdit
+
+[table.action-align-left]
+original=Align left
+translation=Tarigla ɣer zelmeḍ
+
+[table.action-align-center]
+original=Align center
+translation=Tarigla ɣer tlemmast
+
+[table.action-align-right]
+original=Align right
+translation=Tarigla ɣer yeffus
+
+[table.action-delete-selection]
+original=Delete cells
+translation=Kkes tibniqin
+
+[table.action-clear-selection]
+original=Clear cells
+translation=Sfeḍ tibniqin
+
+[table.action-sort-a-z]
+original=Sort by column (A to Z)
+translation=Smizzwer s tgejdit (A ɣer Z)
+
+[table.action-sort-z-a]
+original=Sort by column (Z to A)
+translation=Smizzwer s tgejdit (Z ɣer A)
+
+[table.label-command]
+original=Table: {{command}}
+translation=Tafelwit: {{command}}
+
+[callout.option-type]
+original=Callout type
+translation=Tawsit n ulɣu
+
+[callout.type.info]
+original=Info
+translation=Talɣut
+
+[callout.type.important]
+original=Important
+translation=Axatar
+
+[callout.type.tip]
+original=Tip
+translation=Iwelhen
+
+[callout.type.success]
+original=Success
+translation=Amures
+
+[callout.type.question]
+original=Question
+translation=Asteqsi
+
+[callout.type.warning]
+original=Warning
+translation=Aḥedder
+
+[callout.type.quote]
+original=Quote
+translation=Abdar
+
+[callout.type.example]
+original=Example
+translation=Amedya
+
+[callout.type.none]
+original=None
+translation=Ulac
+
+[callout.option-other]
+original=Other...
+translation=Wayeḍ...
+
+[callout.option-other-placeholder]
+original=Callout type...
+translation=Tawsit n ulɣu...
+
+[nouns.count]
+original={{count}}
+translation={{count}}
+
+[nouns.word-with-count]
+original={{count}} word
+translation={{count}} n wawal
+
+[nouns.word-with-count_plural]
+original={{count}} words
+translation={{count}} n wawalen
+
+[nouns.result-with-count]
+original={{count}} result
+translation={{count}} n ugmuḍ
+
+[nouns.result-with-count_plural]
+original={{count}} results
+translation={{count}} n yigmaḍ
+
+[nouns.character-with-count]
+original={{count}} character
+translation={{count}} n usekkil
+
+[nouns.character-with-count_plural]
+original={{count}} characters
+translation={{count}} n yisekkilen
+
+[nouns.link-with-count]
+original={{count}} link
+translation={{count}} n useɣwen
+
+[nouns.link-with-count_plural]
+original={{count}} links
+translation={{count}} n yiseɣwan
+
+[nouns.file-with-count]
+original={{count}} file
+translation={{count}} n ufaylu
+
+[nouns.file-with-count_plural]
+original={{count}} files
+translation={{count}} n yifuyla
+
+[nouns.folder-with-count]
+original={{count}} folder
+translation={{count}} n ukaram
+
+[nouns.folder-with-count_plural]
+original={{count}} folders
+translation={{count}} n yikaramen
+
+[nouns.backlink-with-count]
+original={{count}} backlink
+translation={{count}} n useɣwen akcam
+
+[nouns.backlink-with-count_plural]
+original={{count}} backlinks
+translation={{count}} n yiseɣwan ikcamen
+
+[nouns.tabs-with-count]
+original={{count}} tab
+translation={{count}} n yiccer
+
+[nouns.tabs-with-count_plural]
+original={{count}} tabs
+translation={{count}} n waccaren
+
+[nouns.properties-with-count]
+original={{count}} property
+translation={{count}} n urat
+
+[nouns.properties-with-count_plural]
+original={{count}} properties
+translation={{count}} n yiraten
+
+[nouns.site-with-count]
+original={{count}} site
+translation={{count}} n usmel
+
+[nouns.site-with-count_plural]
+original={{count}} sites
+translation={{count}} n yismal
+
+[nouns.plugin-with-count]
+original={{count}} plugin
+translation={{count}} n uzegrir
+
+[nouns.plugin-with-count_plural]
+original={{count}} plugins
+translation={{count}} n yizegriren
+
+[nouns.plugin-active-with-count]
+original={{count}} active
+translation={{count}} yermed
+
+[nouns.snippet-active-with-count]
+original={{count}} snippet
+translation={{count}} n ubruy
+
+[nouns.snippet-active-with-count_plural]
+original={{count}} snippets
+translation={{count}} n yibruyen
+
+[nouns.theme-with-count]
+original={{count}} theme
+translation={{count}} n usentel
+
+[nouns.theme-with-count_plural]
+original={{count}} themes
+translation={{count}} n yisental

--- a/translations/kab.txt
+++ b/translations/kab.txt
@@ -404,7 +404,7 @@ translation=Anda ara ttusrusunt tezmiltin timaynutin ara d-yettwarnan.
 
 [setting.file.option-choice-vault-root]
 original=Vault folder
-translation=Akaram uqenduq
+translation=Akaram n weḥraz
 
 [setting.file.option-choice-current-folder]
 original=Same folder as current file
@@ -492,7 +492,7 @@ translation=Isem n ukaram anaddaw
 
 [setting.file.option-attachment-subfolder-path-description]
 original=If your file is in “vault/folder”, and you set subfolder name to “attachments”, attachments will be saved to “vault/folder/attachments”.
-translation=Ma yella ufaylu-ineki·nem deg “vault/folder”, yerna terreḍ isem n udakaram d “attachments”, imeddayen ad ttwaḥerzen deg “vault/folder/attachments”.
+translation=Ma yella ufaylu-inek·inem deg “vault/folder”, yerna terreḍ isem n udakaram d “attachments”, imeddayen ad ttwaḥerzen deg “vault/folder/attachments”.
 
 [setting.file.option-excluded-files]
 original=Excluded files
@@ -520,7 +520,7 @@ translation=Tastayt ur tezmir ara ad tili d tilemt
 
 [setting.file.placeholder-excluded-filter]
 original=Enter path or “/regex/”...
-translation=Sekcem abrid neɣ “/regex/”...
+translation=Sekcem abrid neɣ “/tanfalit tamlugant/”...
 
 [setting.file.option-uri-callbacks]
 original=Allow URI callbacks
@@ -4588,7 +4588,7 @@ translation=Yemṣada d weḍris:
 
 [plugins.search.label-match-regex]
 original=Matches regex: 
-translation=Yemṣada d regex: 
+translation=Yemṣada d tnfalit tamlugant
 
 [plugins.search.label-match-exact-text]
 original=Contains exact text: 


### PR DESCRIPTION
## Description
This PR adds the initial Kabyle (kab) translation for Obsidian. 

## Changes
- Created `kab.txt` based on the English template.
- All keys are translated and follow the original file's order.
- Verified the terminology for consistency with other open-source localizations in Kabyle.