### PR TITLE
Fix Turkish bookmark remove translation

### DIFF
--- a/translations/tr.txt
+++ b/translations/tr.txt
@@ -5648,7 +5648,7 @@ translation=Düzenle...
 
 [plugins.bookmarks.menu-opt-remove]
 original=Remove
-translation=Kaldırmak
+translation=Kaldır
 
 [plugins.bookmarks.menu-opt-rename]
 original=Rename


### PR DESCRIPTION
Fixed the Turkish translation of “Remove” in the bookmarks menu.

“Kaldırmak” was changed to “Kaldır” because it fits menu action wording better in Turkish.