### PR TITLE
feat(website): add official Turkish (tr) translation

### DIFF
--- a/website/locales.json
+++ b/website/locales.json
@@ -18,6 +18,7 @@
 		"ro",
 		"ru",
 		"sv",
+		"tr",
 		"zh"
 	],
 	"localeLabels": {
@@ -35,6 +36,7 @@
 		"ro": "Română",
 		"ru": "Русский",
 		"sv": "Svenska",
+		"tr": "Türkçe",
 		"zh": "简体中文"
 	}
 }

--- a/website/locales.json
+++ b/website/locales.json
@@ -36,6 +36,7 @@
 		"ro": "Romanian",
 		"ru": "Russian",
 		"sv": "Swedish",
+		"tr": "Turkish",
 		"zh": "Chinese Simplified Mandarin"
 	},
 	"localeLabels": {

--- a/website/tr.txt
+++ b/website/tr.txt
@@ -1,0 +1,4967 @@
+[account.account]
+original=Account
+translation=Hesap
+
+[account.back_to_main_site]
+original=Back\u00a0to\u00a0main\u00a0site
+translation=Ana\u00a0siteye\u00a0geri\u00a0dön
+
+[account.billing.apply]
+original=Apply
+translation=Uygula
+
+[account.billing.buy_credit]
+original=Buy credit
+translation=Kredi satın al
+
+[account.billing.credit_balance_suffix]
+original=USD balance
+translation=USD bakiyesi
+
+[account.billing.credit_full_desc]
+original=Credit can be used to pay for any Obsidian license or service, including Sync and Publish. Any credit you have will be used before we charge your payment method.
+translation=Kredi, Sync ve Publish dahil olmak üzere herhangi bir Obsidian lisansı veya hizmeti için ödeme yapmak amacıyla kullanılabilir. Sahip olduğunuz kredi, ödeme yönteminizden ücret tahsil edilmeden önce kullanılacaktır.
+
+[account.billing.credit_purchase_success]
+original=Your Credit purchase was successful! You can now use credit to pay for Sync, Publish, Catalyst, or commercial licenses. You can also send credit to others.
+translation=Kredi satın alma işleminiz başarılı oldu! Artık krediyi Sync, Publish, Catalyst veya ticari lisanslar için ödeme yapmak üzere kullanabilirsiniz. Krediyi başkalarına da gönderebilirsiniz.
+
+[account.billing.discount]
+original=Discount
+translation=İndirim
+
+[account.billing.discount_active]
+original=Your {{type}} discount currently gives you 40% off the regular price of Obsidian Sync and Publish. Your discount will expire on {{date}}.
+translation={{type}} indiriminiz şu anda size normal Obsidian Sync ve Publish fiyatı üzerinden %40 indirim sağlamaktadır. İndiriminizin geçerlilik süresi {{date}} tarihinde dolacaktır.
+
+[account.billing.discount_eligibility]
+original=Students, faculty members, and nonprofit employees are eligible for a 40% discount on Obsidian Sync and\u00a0Publish.
+translation=Öğrenciler, öğretim üyeleri ve kâr amacı gütmeyen kuruluş çalışanları Obsidian Sync ve\u00a0Publish'te %40 indirimden yararlanabilir.
+
+[account.billing.discount_expired]
+original=Your {{type}} discount expired on {{date}}.
+translation={{type}} indiriminizin süresi {{date}} tarihinde doldu.
+
+[account.billing.discount_submitted]
+original=You have submitted your school or organization email, but have not completed email verification yet. Please check your email for a link to verify your email address.
+translation=Okul veya kuruluş e-postanızı gönderdiniz ancak henüz e-posta doğrulamasını tamamlamadınız. E-posta adresinizi doğrulamak üzere bir bağlantı için lütfen e-postanızı kontrol edin.
+
+[account.billing.discount_verified]
+original=Your discount application has been submitted for review. Thanks for your patience!
+translation=İndirim başvurunuz inceleme üzere gönderildi. Sabrınız için teşekkürler!
+
+[account.billing.gift_cancel_confirm]
+original=Are you sure you want to cancel this gift? Your credit will be refunded, and the recipient will no longer be able to redeem it.
+translation=Bu hediyeyi iptal etmek istediğinizden emin misiniz? Krediniz iade edilecek ve alıcı artık hediyeyi kullanamayacaktır.
+
+[account.billing.gift_cancel_link]
+original=Cancel this gift
+translation=Bu hediyeyi iptal et
+
+[account.billing.gift_cancelled_on]
+original=Your gift was cancelled on {{date}}.
+translation=Hediyeniz {{date}} tarihinde iptal edildi.
+
+[account.billing.gift_copy]
+original=Copy
+translation=Kopyala
+
+[account.billing.gift_empty]
+original=You haven’t sent or received any\u00a0credit.
+translation=Henüz hiç kredi\u00a0göndermediniz veya almadınız.
+
+[account.billing.gift_history]
+original=Gift history
+translation=Hediye geçmişi
+
+[account.billing.gift_or]
+original=or
+translation=veya
+
+[account.billing.gift_received]
+original=You redeemed {{amount}} worth of gift credit on {{date}}.
+translation={{date}} tarihinde {{amount}} tutarında hediye kredi kullandınız.
+
+[account.billing.gift_redeem_code]
+original=redeem code
+translation=kodu kullan
+
+[account.billing.gift_redeem_link]
+original=redeem link
+translation=bağlantıyı kullan
+
+[account.billing.gift_redeemed_on]
+original=Your gift was redeemed on {{date}}.
+translation=Hediyeniz {{date}} tarihinde kullanıldı.
+
+[account.billing.gift_sent]
+original=You sent {{amount}} to "{{recipient}}" on {{date}}.
+translation={{date}} tarihinde "{{recipient}}" adlı alıcıya {{amount}} gönderdiniz.
+
+[account.billing.gift_waiting]
+original=Waiting for recipient to redeem gift.
+translation=Alıcının hediyeyi kullanması bekleniyor.
+
+[account.billing.invoices]
+original=Invoices and refunds
+translation=Faturalar ve iadeler
+
+[account.billing.invoices_desc]
+original=Download invoices for your past payments and request\u00a0refunds.
+translation=Geçmiş ödemeleriniz için faturaları indirin ve iade\u00a0talebinde bulunun.
+
+[account.billing.learn_more]
+original=Learn more.
+translation=Daha fazla bilgi edinin.
+
+[account.billing.manage]
+original=Manage
+translation=Yönet
+
+[account.billing.obsidian_credit]
+original=Obsidian Credit
+translation=Obsidian Kredisi
+
+[account.billing.payment_method]
+original=Payment method
+translation=Ödeme yöntemi
+
+[account.billing.payment_method_desc]
+original=View and modify the card you use for payments
+translation=Ödemeler için kullandığınız kartı görüntüleyin ve düzenleyin
+
+[account.billing.redeem]
+original=Redeem
+translation=Kullan
+
+[account.billing.renew]
+original=Renew
+translation=Yenile
+
+[account.billing.send_credit]
+original=Send credit
+translation=Kredi gönder
+
+[account.billing.tax_ca_unavailable]
+original=Tax exemptions are not available in Canada.
+translation=Kanada'da vergi muafiyeti uygulanamamaktadır.
+
+[account.billing.tax_cert_desc]
+original=Upload an image or PDF containing your tax exemption certificate. Maximum 3MB file size.
+translation=Vergi muafiyeti belgenizi içeren bir görsel veya PDF yükleyin. Maksimum dosya boyutu 3 MB.
+
+[account.billing.tax_cert_file]
+original=Certificate file
+translation=Sertifika dosyası
+
+[account.billing.tax_cert_title]
+original=Tax exemption certificate
+translation=Vergi muafiyeti belgesi
+
+[account.billing.tax_certs_title]
+original=Your exemption certificates
+translation=Muafiyet belgeleriniz
+
+[account.billing.tax_col_created]
+original=Created
+translation=Oluşturulma Tarihi
+
+[account.billing.tax_col_remove]
+original=Remove
+translation=Kaldır
+
+[account.billing.tax_col_state]
+original=State
+translation=Eyalet/Bölge
+
+[account.billing.tax_country]
+original=Country
+translation=Ülke
+
+[account.billing.tax_delete_error]
+original=Failed to delete certificate. Please try again.
+translation=Belge silinemedi. Lütfen tekrar deneyin.
+
+[account.billing.tax_delete_success]
+original=Successfully deleted
+translation=Başarıyla silindi
+
+[account.billing.tax_delete_success_desc]
+original=Your exemption certificate has been deleted.
+translation=Muafiyet belgeniz silindi.
+
+[account.billing.tax_enter_postal]
+original=Please enter your postal code
+translation=Lütfen posta kodunuzu girin
+
+[account.billing.tax_exemption]
+original=Tax exemption
+translation=Vergi muafiyeti
+
+[account.billing.tax_exemption_desc]
+original=Add and manage tax exemptions.
+translation=Vergi muafiyetlerini ekleyin ve yönetin.
+
+[account.billing.tax_intro]
+original=Obsidian is required to collect taxes in certain jurisdictions. We use your location to determine the taxes that should be applied.
+translation=Obsidian belirli yargı bölgelerinde vergi toplamakla yükümlüdür. Uygulanacak vergileri belirlemek için konumunuzu kullanırız.
+
+[account.billing.tax_learn_more]
+original=Learn\u00a0more
+translation=Daha\u00a0fazla\u00a0bilgi\u00a0edinin
+
+[account.billing.tax_location]
+original=Location
+translation=Konum
+
+[account.billing.tax_max_size]
+original=Exceeded maximum attachment size.
+translation=Maksimum ek boyutu aşıldı.
+
+[account.billing.tax_select_country]
+original=Please select your country
+translation=Lütfen ülkenizi seçin
+
+[account.billing.tax_select_file]
+original=Please select a file to upload.
+translation=Lütfen yüklenecek bir dosya seçin.
+
+[account.billing.tax_single_file]
+original=Please select a single file to upload.
+translation=Lütfen yüklemek için tek bir dosya seçin.
+
+[account.billing.tax_title]
+original=Sales tax
+translation=Satış vergisi
+
+[account.billing.tax_upload]
+original=Upload
+translation=Yükle
+
+[account.billing.tax_upload_success]
+original=Successfully uploaded
+translation=Başarıyla yüklendi
+
+[account.billing.tax_upload_success_desc]
+original=Your tax exemption certificate has been received.
+translation=Vergi muafiyeti belgeniz alındı.
+
+[account.billing.tax_vat_desc]
+original=Depending on your location, you may add your Tax Identification Number (TIN), VAT Number, or VAT ID. The format depends on your country.
+translation=Konumunuza bağlı olarak Vergi Kimlik Numaranızı (TIN), KDV Numaranızı veya KDV Kimliğinizi ekleyebilirsiniz. Format ülkenize bağlıdır.
+
+[account.billing.tax_vat_label]
+original=VAT number
+translation=KDV numarası
+
+[account.billing.tax_vat_placeholder]
+original=VAT number
+translation=KDV numarası
+
+[account.billing.tax_vat_success]
+original=Successfully saved
+translation=Başarıyla kaydedildi
+
+[account.billing.tax_vat_success_desc]
+original=Your VAT number has been received.
+translation=KDV numaranız alındı.
+
+[account.billing.tax_vat_title]
+original=VAT number
+translation=KDV numarası
+
+[account.billing.tax_zip_code]
+original=Zip code
+translation=Posta kodu
+
+[account.billing.tax_zip_placeholder]
+original=Your zip code
+translation=Posta kodunuz
+
+[account.billing.title]
+original=Billing
+translation=Faturalandırma
+
+[account.billing.view]
+original=View
+translation=Görüntüle
+
+[account.catalyst.badge_error]
+original=Please contact us for support or try again later. We’re really sorry for the inconvenience!
+translation=Lütfen destek için bizimle iletişime geçin veya daha sonra tekrar deneyin. Verdiğimiz rahatsızlıktan dolayı gerçekten çok üzgünüz!
+
+[account.catalyst.badge_thanks]
+original=Thanks for supporting Obsidian! Your support helps us stay independent so we can pursue our vision.
+translation=Obsidian'ı desteklediğiniz için teşekkürler! Desteğiniz bağımsız kalmamıza ve vizyonumuzu sürdürmemize yardımcı oluyor.
+
+[account.catalyst.become_catalyst]
+original=Become a Catalyst member
+translation=Catalyst üyesi olun
+
+[account.catalyst.buy_catalyst]
+original=Join Catalyst
+translation=Catalyst'e Katıl
+
+[account.catalyst.discord_failure]
+original=Couldn’t add Discord badge
+translation=Discord rozeti eklenemedi
+
+[account.catalyst.discord_success]
+original=Added Discord badge
+translation=Discord rozeti eklendi
+
+[account.catalyst.discord_success_msg]
+original=Successfully added badge for you!
+translation=Rozetiniz başarıyla eklendi!
+
+[account.catalyst.early_access]
+original=To get early access to new versions of Obsidian, {{link}}.
+translation=Obsidian'ın yeni sürümlerine erken erişim sağlamak için {{link}}.
+
+[account.catalyst.early_access_link]
+original=see this guide
+translation=bu rehbere göz atın
+
+[account.catalyst.forum_badge_note]
+original=P.S. Your forum badge is not a "badge" in the forum system, but a shiny gold tag right next to your name in all of your posts. Hope that helps!
+translation=Not: Forum rozetiniz forum sisteminde klasik bir rozet değil, tüm gönderilerinizde adınızın hemen yanında yer alan parlak altın sarısı bir etikettir. Umarız faydalı olur!
+
+[account.catalyst.forum_failure]
+original=Couldn’t add forum badge
+translation=Forum rozeti eklenemedi
+
+[account.catalyst.forum_success]
+original=Added forum badge
+translation=Forum rozeti eklendi
+
+[account.catalyst.forum_success_msg]
+original=Successfully added badge for you!
+translation=Rozetiniz başarıyla eklendi!
+
+[account.catalyst.get_discord_badge]
+original=Get Discord badge
+translation=Discord rozeti al
+
+[account.catalyst.get_forum_badge]
+original=Get forum badge
+translation=Forum rozeti al
+
+[account.catalyst.insider]
+original=Insider
+translation=Insider
+
+[account.catalyst.learn_more]
+original=Learn more.
+translation=Daha fazla bilgi edinin.
+
+[account.catalyst.licensed_thanks]
+original=Thank you for being a Catalyst member. Your support helps us remain 100% independent and build Obsidian without compromising {{link}}.
+translation=Catalyst üyesi olduğunuz için teşekkür ederiz. Desteğiniz %100 bağımsız kalmamıza ve {{link}} ödün vermeden Obsidian'ı geliştirmemize yardımcı oluyor.
+
+[account.catalyst.not_licensed_desc]
+original=Support development with a one-time donation that gives you early access to beta versions of Obsidian and special badges in the\u00a0community.
+translation=Obsidian'ın beta sürümlerine erken erişim ve toplulukta özel rozetler kazandıran tek seferlik bir bağışla geliştirmeye destek olun.
+
+[account.catalyst.not_refundable]
+original=Licenses are not refundable. See our {{link}}.
+translation=Lisanslar iade edilemez. {{link}} inceleyin.
+
+[account.catalyst.one_time]
+original=one-time donation
+translation=tek seferlik bağış
+
+[account.catalyst.our_values_link]
+original=our values
+translation=değerlerimiz
+
+[account.catalyst.purchase_success]
+original=Your Catalyst purchase was successful. Thank you so much for your support!
+translation=Catalyst satın alma işleminiz başarılı oldu. Desteğiniz için çok teşekkür ederiz!
+
+[account.catalyst.refund_policy_link]
+original=refund policy
+translation=iade politikamızı
+
+[account.catalyst.supporter]
+original=Supporter
+translation=Destekçi
+
+[account.catalyst.title]
+original=Catalyst
+translation=Catalyst
+
+[account.catalyst.upgrade]
+original=Upgrade to a higher tier
+translation=Daha üst bir seviyeye yükseltin
+
+[account.catalyst.vip]
+original=VIP
+translation=VIP
+
+[account.checkout]
+original=Checkout
+translation=Ödeme
+
+[account.commercial.activate_license]
+original=To activate your commercial license, go to Settings → General in Obsidian.
+translation=Ticari lisansınızı etkinleştirmek için Obsidian'da Ayarlar → Genel bölümüne gidin.
+
+[account.commercial.auto_renewal]
+original=Auto-renewal
+translation=Otomatik yenileme
+
+[account.commercial.buy_license]
+original=Buy license
+translation=Lisans satın al
+
+[account.commercial.change_success]
+original=The number of seats on your license has been successfully changed!
+translation=Lisansınızdaki kullanıcı sayısı başarıyla değiştirildi!
+
+[account.commercial.invoices]
+original=Invoices
+translation=Faturalar
+
+[account.commercial.invoices_desc]
+original=View and print invoices for your commercial license.
+translation=Ticari lisansınız için faturaları görüntüleyin ve yazdırın.
+
+[account.commercial.learn_more]
+original=Learn\u00a0more.
+translation=Daha\u00a0fazla\u00a0bilgi\u00a0edinin.
+
+[account.commercial.license_desc]
+original=Support development by purchasing commercial licenses for your team. Organizations with 25 or more licenses can join our featured supporters page.
+translation=Support ekibiniz için ticari lisanslar satın alarak geliştirmeye destek olun. 25 veya daha fazla lisansa sahip kuruluşlar, öne çıkan destekçiler sayfamıza katılabilir.
+
+[account.commercial.license_expires]
+original=Your license expires {{date}}. Your license will not be\u00a0renewed.
+translation=Lisansınızın süresi {{date}} tarihinde dolacak. Lisansınız yenilenmeyecektir.
+
+[account.commercial.license_key]
+original=Your license key is:
+translation=Lisans anahtarınız:
+
+[account.commercial.nav_label]
+original=License
+translation=Lisans
+
+[account.commercial.next_renewal]
+original=Your next renewal will be {{date}}.
+translation=Bir sonraki yenileme tarihiniz {{date}} olacaktır.
+
+[account.commercial.not_licensed_desc]
+original=Commercial licenses are optional and help Obsidian remain 100% user-supported. Licenses are not refundable. See our {{link}}.
+translation=Ticari lisanslar isteğe bağlıdır ve Obsidian'ın %100 kullanıcı destekli kalmasına yardımcı olur. Lisanslar iade edilemez. {{link}} inceleyin.
+
+[account.commercial.per_user_year]
+original=per user, per\u00a0year
+translation=kullanıcı başına, yıllık
+
+[account.commercial.purchase_success]
+original=Your purchase was successful. Thank you for your support!
+translation=Satın alma işleminiz başarılı oldu. Desteğiniz için teşekkür ederiz!
+
+[account.commercial.refund_policy_link]
+original=refund policy
+translation=iade politikamızı
+
+[account.commercial.registered_to]
+original=Registered to "{{company}}" for {{seats}}. Valid until {{date}}.
+translation={{seats}} kullanıcı için "{{company}}" adına kayıtlıdır. {{date}} tarihine kadar geçerlidir.
+
+[account.commercial.resume]
+original=Resume
+translation=Devam ettir
+
+[account.commercial.seat_count]
+original={{count}} seats
+translation={{count}} kullanıcı
+
+[account.commercial.seat_one]
+original=1 seat
+translation=1 kullanıcı
+
+[account.commercial.seats]
+original=Seats
+translation=Kullanıcı
+
+[account.commercial.seats_purchased]
+original={{seats}} purchased.
+translation={{seats}} adet satın alındı.
+
+[account.commercial.stop]
+original=Stop
+translation=Durdur
+
+[account.commercial.title]
+original=Commercial license
+translation=Ticari lisans
+
+[account.commercial.update_seats]
+original=Update seats
+translation=Kullanıcı sayısını güncelle
+
+[account.commercial.view]
+original=View
+translation=Görüntüle
+
+[account.discount.apply_intro]
+original=Choose the discount type you’re applying for and enter your school or organization email. We will send an email to this email address to verify\u00a0it.
+translation=Başvurduğunuz indirim türünü seçin ve okul veya kuruluş e-postanızı girin. E-posta adresinizi doğrulamak için bu adrese bir e-posta göndereceğiz.
+
+[account.discount.apply_title]
+original=Apply for a discount
+translation=İndirim için başvurun
+
+[account.discount.approved_desc]
+original=Your {{type}} discount is approved!
+translation={{type}} indiriminiz onaylandı!
+
+[account.discount.approved_info]
+original=You’ll see the discount applied when you try to buy Obsidian Sync or Obsidian Publish. It’s not applicable to Catalyst or commercial licenses.
+translation=Obsidian Sync veya Obsidian Publish satın almayı denediğinizde indirimin uygulandığını göreceksiniz. Catalyst veya ticari lisanslar için geçerli değildir.
+
+[account.discount.approved_title]
+original=Your discount is active
+translation=İndiriminiz aktif
+
+[account.discount.contact_note]
+original=If you do not have an organization email, please {{link}} to provide other forms of verification, such as a student ID card, transcript, or employee ID card.
+translation=Bir kuruluş e-postanız yoksa öğrenci kimlik kartı, transkript veya personel kimlik kartı gibi diğer doğrulama yöntemlerini sağlamak için lütfen {{link}}.
+
+[account.discount.contact_note_link]
+original=contact us
+translation=bizimle iletişime geçin
+
+[account.discount.discount_type]
+original=Discount type
+translation=İndirim türü
+
+[account.discount.early_bird_note]
+original=Note that if you have an early bird discount, discounts will not\u00a0stack.
+translation=Erken kayıt indiriminiz varsa indirimlerin birleşmeyeceğini unutmayın.
+
+[account.discount.education]
+original=Education (student or faculty)
+translation=Eğitim (öğrenci veya öğretim üyesi)
+
+[account.discount.invalid_email_error]
+original=Please enter a valid organization email address.
+translation=Lütfen geçerli bir kuruluş e-posta adresi girin.
+
+[account.discount.nonprofit]
+original=Non-profit organization
+translation=Kâr amacı gütmeyen kuruluş
+
+[account.discount.org_email]
+original=School or organization email
+translation=Okul veya kuruluş e-postası
+
+[account.discount.org_email_placeholder]
+original=Enter your email...
+translation=E-postanızı girin...
+
+[account.discount.select_type_error]
+original=Please select a discount type.
+translation=Lütfen bir indirim türü seçin.
+
+[account.discount.send_application]
+original=Send application
+translation=Başvuruyu gönder
+
+[account.discount.verified_thanks]
+original=Thanks for verifying your organization email! We’ll take a look at your application as soon as we can.
+translation=Kuruluş e-postanızı doğruladığınız için teşekkürler! Başvurunuzu mümkün olan en kısa sürede inceleyeceğiz.
+
+[account.discount.verified_title]
+original=Organization email verified
+translation=Kuruluş e-postası doğrulandı
+
+[account.discount.verified_update]
+original=You’ll get an email update when your discount application is approved. Have a nice day!
+translation=İndirim başvurunuz onaylandığında e-posta ile bilgilendirileceksiniz. İyi günler dileriz!
+
+[account.discount.verify_sent]
+original=We’ve sent an email to your organization email address to verify your email. Once you click on the link, the application will be submitted for review.
+translation=E-postanızı doğrulamak için kuruluş e-posta adresinize bir e-posta gönderdik. Bağlantıya tıkladığınızda başvuru inceleme üzere gönderilecektir.
+
+[account.discount.verify_spam]
+original=If you don’t see the email in a few minutes, please try checking your spam folder. You can try applying for a discount again.
+translation=E-postayı birkaç dakika içinde görmezseniz lütfen spam klasörünüzü kontrol etmeyi deneyin. İndirim için tekrar başvurmayı deneyebilirsiniz.
+
+[account.discount.verify_thanks]
+original=Thanks for applying for Obsidian discount!
+translation=Obsidian indirimi için başvurduğunuz için teşekkür ederiz!
+
+[account.discount.verify_title]
+original=Verify your email
+translation=E-postanızı doğrulayın
+
+[account.gift.amount_exceeds]
+original=You cannot gift more credit than you currently have.
+translation=Şu anda sahip olduğunuzdan daha fazla kredi hediye edemezsiniz.
+
+[account.gift.amount_invalid]
+original=Please enter a valid gift amount.
+translation=Lütfen geçerli bir hediye tutarı girin.
+
+[account.gift.amount_label]
+original=Amount to send (USD)
+translation=Gönderilecek tutar (USD)
+
+[account.gift.amount_min]
+original=You need to gift at least $5.
+translation=En az 5$ hediye etmeniz gerekir.
+
+[account.gift.amount_min_full]
+original=You need to gift at least $5 worth of Obsidian Credit.
+translation=En az 5$ değerinde Obsidian Kredisi hediye etmeniz gerekir.
+
+[account.gift.amount_received]
+original=You cannot gift credit which was received from another account.
+translation=Başka bir hesaptan alınan krediyi hediye edemezsiniz.
+
+[account.gift.code_copied]
+original=The gift redeem code has been copied to your clipboard.
+translation=Hediye kullanma kodu panonuza kopyalandı.
+
+[account.gift.copied_code]
+original=Copied redeem code
+translation=Kullanma kodu kopyalandı
+
+[account.gift.copied_link]
+original=Copied redeem link
+translation=Kullanma bağlantısı kopyalandı
+
+[account.gift.credit_to_send]
+original=Credit to send
+translation=Gönderilecek kredi
+
+[account.gift.current_balance]
+original=Current balance
+translation=Mevcut bakiye
+
+[account.gift.eligible_to_gift]
+original=Credit eligible to gift
+translation=Hediye edilebilir kredi
+
+[account.gift.email_invalid]
+original=Please enter valid recipient email.
+translation=Lütfen geçerli bir alıcı e-postası girin.
+
+[account.gift.email_required]
+original=Please enter email of the recipient so we can send the gift for you!
+translation=Hediyeyi sizin adınıza gönderebilmemiz için lütfen alıcının e-postasını girin!
+
+[account.gift.enter_code_error]
+original=Please enter a redeem code.
+translation=Lütfen bir kullanma kodu girin.
+
+[account.gift.get_redeem_link]
+original=Get redeem link
+translation=Kullanma bağlantısını al
+
+[account.gift.gift_code_label]
+original=Your gift code
+translation=Hediye kodunuz
+
+[account.gift.gift_code_placeholder]
+original=Enter your gift code...
+translation=Hediye kodunu girin...
+
+[account.gift.link_copied]
+original=The link to redeem the gift has been copied to your clipboard.
+translation=Hediyeyi kullanmak için gereken bağlantı panonuza kopyalandı.
+
+[account.gift.method]
+original=Method
+translation=Yöntem
+
+[account.gift.method_code_desc]
+original=You’ll get a link to redeem the credit. Choose this if you want to send the link to the recipient yourself.
+translation=Krediyi kullanmak için bir bağlantı alacaksınız. Bağlantıyı alıcıya kendiniz göndermek istiyorsanız bunu seçin.
+
+[account.gift.method_email_desc]
+original=We’ll send an email on your behalf. Choose this if you want to stay anonymous or want it to be a surprise.
+translation=Sizin adınıza bir e-posta göndereceğiz. Anonim kalmak veya sürpriz olmasını istiyorsanız bunu seçin.
+
+[account.gift.not_redeemed]
+original=Gift not redeemed
+translation=Hediye kullanılmadı
+
+[account.gift.not_redeemed_desc]
+original=Unfortunately, we were unable to redeem your gift for you.
+translation=Maalesef hediyenizi sizin adınıza kullanamadık.
+
+[account.gift.recipient_email]
+original=Recipient email
+translation=Alıcı e-postası
+
+[account.gift.recipient_email_placeholder]
+original=Enter recipient email...
+translation=Alıcı e-postası girin...
+
+[account.gift.recipient_name]
+original=Recipient name
+translation=Alıcı adı
+
+[account.gift.recipient_name_placeholder]
+original=Enter recipient name...
+translation=Alıcı adı girin...
+
+[account.gift.redeem_btn]
+original=Redeem
+translation=Kullan
+
+[account.gift.redeem_error]
+original=Unfortunately, we were unable to fetch your gift.
+translation=Maalesef hediyenizi çekemedik.
+
+[account.gift.redeem_prompt]
+original=Someone has sent you a gift worth of {{amount}} Obsidian Credit. How exciting!
+translation=Birisi size {{amount}} değerinde Obsidian Kredisi gönderdi. Ne kadar heyecan verici!
+
+[account.gift.redeem_title]
+original=Redeem your credit
+translation=Kredinizi kullanın
+
+[account.gift.redeemed_info]
+original=You should be able to see the credit in the "Obsidian Credit" section. You can use it to buy any Obsidian service you want.
+translation=Krediyi "Obsidian Kredisi" bölümünde görebilmeniz gerekir. İstediğiniz Obsidian hizmetini satın almak için kullanabilirsiniz.
+
+[account.gift.redeemed_success]
+original=Your gift was successfully redeemed!
+translation=Hediyeniz başarıyla kullanıldı!
+
+[account.gift.redeemed_title]
+original=Gift redeemed
+translation=Hediye kullanıldı
+
+[account.gift.remaining_balance]
+original=Remaining balance
+translation=Kalan bakiye
+
+[account.gift.send_credit]
+original=Send credit
+translation=Kredi gönder
+
+[account.gift.send_intro]
+original=You can send Obsidian Credit to anyone, such as friends, family, and coworkers. Credit can be used to pay for any Obsidian license or service. The minimum you can send is $5\u00a0USD.
+translation=You can send Obsidian Credit to anyone, such as friends, family, and coworkers. Credit can be used to pay for any Obsidian license or service. The minimum you can send is $5\u00a0USD.
+
+[account.gift.send_only_purchased]
+original=You may only send credit which you purchased. Credit received from another account may not be sent.
+translation=Yalnızca satın aldığınız krediyi gönderebilirsiniz. Başka bir hesaptan alınan kredi gönderilemez.
+
+[account.gift.send_title]
+original=Send credit
+translation=Kredi gönder
+
+[account.gift.send_via_email]
+original=Send anonymously via email
+translation=E-posta ile anonim olarak gönder
+
+[account.gift.sent_success]
+original=Successfully sent gift
+translation=Hediye başarıyla gönderildi
+
+[account.gift.sent_to]
+original=You just sent a gift of {{amount}} to "{{name}}"!
+translation="{{name}}" adlı kişiye {{amount}} tutarında bir hediye gönderdiniz!
+
+[account.gift.summary]
+original=Summary
+translation=Özet
+
+[account.invoice.bill_to]
+original=Bill to
+translation=Fatura Alıcısı
+
+[account.invoice.billing_info_placeholder]
+original=Click to edit your billing information
+translation=Fatura bilgilerinizi düzenlemek için tıklayın
+
+[account.invoice.confirm_refund]
+original=Confirm refund
+translation=İadeyi onayla
+
+[account.invoice.credit_used]
+original=Credit used
+translation=Kullanılan kredi
+
+[account.invoice.discount]
+original=Discount
+translation=İndirim
+
+[account.invoice.invoice_number]
+original=Invoice #{{number}}
+translation=Fatura #{{number}}
+
+[account.invoice.invoice_paid]
+original=Invoice #{{number}} (Paid)
+translation=Fatura #{{number}} (Ödendi)
+
+[account.invoice.invoice_refunded]
+original=Invoice #{{number}} (Refunded)
+translation=Fatura #{{number}} (İade Edildi)
+
+[account.invoice.invoice_title]
+original=Invoice #{{num}}
+translation=Fatura #{{num}}
+
+[account.invoice.items]
+original=Items
+translation=Kalemler
+
+[account.invoice.no_invoices]
+original=There are no invoices for this account.
+translation=Bu hesap için fatura bulunmamaktadır.
+
+[account.invoice.paid]
+original=Paid
+translation=Ödendi
+
+[account.invoice.price]
+original=Price
+translation=Fiyat
+
+[account.invoice.print]
+original=Print invoice
+translation=Faturayı yazdır
+
+[account.invoice.refund]
+original=Refund
+translation=İade
+
+[account.invoice.refund_failed]
+original=Refund failed
+translation=İade başarısız oldu
+
+[account.invoice.refund_failed_contact]
+original=If you believe you still qualify for a refund, you can contact our support at support@obsidian.md.
+translation=Hâlâ iade koşullarını karşıladığınızı düşünüyorsanız support@obsidian.md adresinden desteğimizle iletişime geçebilirsiniz.
+
+[account.invoice.refund_failed_desc]
+original=Automatic refund has failed. {{error}}
+translation=Otomatik iade başarısız oldu. {{error}}
+
+[account.invoice.refund_publish_warning]
+original=Your Obsidian Publish sites will be immediately deleted.
+translation=Obsidian Publish siteleriniz derhal silinecektir.
+
+[account.invoice.refund_question]
+original=Would you like to request a refund for this payment?
+translation=Bu ödeme için iade talebinde bulunmak istiyor musunuz?
+
+[account.invoice.refund_success]
+original=Refund success
+translation=İade başarılı
+
+[account.invoice.refund_success_days]
+original=You should receive your refund in a few business days. Thanks for trying Obsidian!
+translation=İadenizi birkaç iş günü içinde almanız gerekir. Obsidian'ı denediğiniz için teşekkürler!
+
+[account.invoice.refund_success_processed]
+original=Your refund request has been successfully processed!
+translation=İade talebiniz başarıyla işleme alındı!
+
+[account.invoice.refund_success_removed]
+original=The service or license you purchased has been removed, and your auto-renewal has been canceled.
+translation=Satın aldığınız hizmet veya lisans kaldırıldı ve otomatik yenilemeniz iptal edildi.
+
+[account.invoice.refund_sync_warning]
+original=Your Obsidian Sync remote vaults will be immediately deleted.
+translation=Obsidian Sync uzak kasalarınız derhal silinecektir.
+
+[account.invoice.refund_total]
+original=Refund:
+translation=İade Tutarı:
+
+[account.invoice.refund_warning]
+original=The service or license you purchased will be removed, and this action is not\u00a0reversible. Your auto-renewal will also be canceled.
+translation=Satın aldığınız hizmet veya lisans kaldırılacaktır ve bu işlem geri\u00a0alınamaz. Otomatik yenilemeniz de iptal edilecektir.
+
+[account.invoice.refunded]
+original=Refunded
+translation=İade Edildi
+
+[account.invoice.request_refund]
+original=Request refund
+translation=İade talep et
+
+[account.invoice.tax]
+original=Tax
+translation=Vergi
+
+[account.invoice.total]
+original=Total:
+translation=Toplam:
+
+[account.invoice.view]
+original=View
+translation=Görüntüle
+
+[account.invoice.your_invoices]
+original=Your invoices
+translation=Faturalarınız
+
+[account.log_out]
+original=Log\u00a0out
+translation=Çıkış\u00a0yap
+
+[account.payment.change_card]
+original=Change card
+translation=Kartı değiştir
+
+[account.payment.current_method]
+original=You’re currently using a {{method}}.
+translation=Şu anda bir {{method}} kullanıyorsunuz.
+
+[account.payment.load_error]
+original=Unable to load payment information. Please try again.
+translation=Ödeme bilgi yüklenemedi. Lütfen tekrar deneyin.
+
+[account.payment.new_card_desc]
+original=Enter the details of your new card below. Your card will not be charged until the next renewal date.
+translation=Yeni kartınızın bilgilerini aşağıya girin. Bir sonraki yenileme tarihine kadar kartınızdan ücret tahsil edilmeyecektir.
+
+[account.payment.no_payment_method]
+original=You currently do not have any payment methods on file.
+translation=Şu anda kayıtlı bir ödeme yönteminiz bulunmuyor.
+
+[account.payment.paypal_cad_desc]
+original=As a Canadian company we are required by PayPal to charge in CAD (Canadian dollars). If you are paying in any other currency, PayPal will charge a conversion fee of about 4.5%.
+translation=Kanadalı bir şirket olarak PayPal tarafından CAD (Kanada doları) cinsinden ücret almamız gerekmektedir. Başka bir para biriminde ödeme yapıyorsanız PayPal yaklaşık %4,5 oranında bir çevrim ücreti tahsil edecektir.
+
+[account.payment.paypal_card_suggestion]
+original=To avoid currency conversion fees, you can return to the previous step and use a credit card.
+translation=Para birimi çevrim ücretlerinden kaçınmak için bir önceki adıma dönebilir ve kredi kartı kullanabilirsiniz.
+
+[account.payment.paypal_pay_alt]
+original=Pay with PayPal
+translation=PayPal ile Öde
+
+[account.payment.paypal_title]
+original=PayPal currency conversion
+translation=PayPal para birimi çevrimi
+
+[account.payment.paypal_update]
+original=If you subscribed with PayPal, {{link}} to update your subscription.
+translation=PayPal ile abone olduysanız aboneliğinizi güncellemek için {{link}}.
+
+[account.payment.paypal_update_link]
+original=click here
+translation=buraya tıklayın
+
+[account.payment.update]
+original=Update
+translation=Güncelle
+
+[account.profile.action_irreversible]
+original=This action is not reversible.
+translation=Bu işlem geri alınamaz.
+
+[account.profile.change]
+original=Change
+translation=Değiştir
+
+[account.profile.change_email]
+original=Change your email
+translation=E-postanızı değiştirin
+
+[account.profile.change_name]
+original=Change your name
+translation=Adınızı değiştirin
+
+[account.profile.change_password]
+original=Change your password
+translation=Şifrenizi değiştirin
+
+[account.profile.confirm_change]
+original=Confirm change
+translation=Değişikliği onayla
+
+[account.profile.confirm_log_out]
+original=Confirm log out
+translation=Çıkışı onayla
+
+[account.profile.contact_support]
+original=Contact support
+translation=Destek ekibiyle iletişime geçin
+
+[account.profile.contact_support_desc]
+original=Reach us for account, billing, or paid service\u00a0inquiries.
+translation=Hesap, faturalandırma veya ücretli hizmetlerle\u00a0ilgili sorularınız için bize ulaşın.
+
+[account.profile.current_password]
+original=Current password
+translation=Mevcut şifre
+
+[account.profile.current_password_empty_error]
+original=Current password cannot be empty.
+translation=Mevcut şifre alanı boş bırakılamaz.
+
+[account.profile.delete]
+original=Delete
+translation=Sil
+
+[account.profile.delete_account]
+original=Delete account
+translation=Hesabı sil
+
+[account.profile.delete_account_confirm]
+original=Confirm deletion
+translation=Silme işlemini onayla
+
+[account.profile.delete_account_desc]
+original=Permanently delete your account, licenses, and subscriptions. You will be asked for confirmation before deletion\u00a0proceeds.
+translation=Hesabınızı, lisanslarınızı ve aboneliklerinizi kalıcı olarak silin. Silme işlemi\u00a0başlamadan önce sizden onay istenecektir.
+
+[account.profile.delete_account_title]
+original=Delete your account
+translation=Hesabınızı silin
+
+[account.profile.delete_confirm_prompt]
+original=If you fully understand the consequences outlined above and still wish to proceed, please confirm by entering your email and password below:
+translation=Yukarıda belirtilen sonuçları tamamen anladıysanız ve yine de devam etmek istiyorsanız lütfen aşağıdaki e-posta adresinizi ve şifrenizi girerek onaylayın:
+
+[account.profile.delete_data_deleted]
+original=Your Obsidian Sync remote vaults and Obsidian Publish sites will be permanently deleted.
+translation=Obsidian Sync uzak kasalarınız ve Obsidian Publish siteleriniz kalıcı olarak silinecektir.
+
+[account.profile.delete_email_error]
+original=Please enter your email to confirm account deletion.
+translation=Hesap silme işlemini onaylamak için lütfen e-posta adresinizi girin.
+
+[account.profile.delete_intro]
+original=Deleting your account is a permanent action with significant consequences. Before proceeding, carefully review the following information:
+translation=Hesabınızı silmek, ciddi sonuçları olan kalıcı bir işlemdir. Devam etmeden önce aşağıdaki bilgileri dikkatlice inceleyin:
+
+[account.profile.delete_irreversible_warning]
+original=Important: Account deletion is irreversible. Once your account is deleted, it cannot be recovered under any circumstances.
+translation=Önemli: Hesap silme işlemi geri alınamaz. Hesabınız silindikten sonra hiçbir koşulda kurtarılamaz.
+
+[account.profile.delete_licenses_revoked]
+original=All your commercial licenses and Catalyst licenses will be\u00a0revoked.
+translation=Tüm ticari lisanslarınız ve Catalyst lisanslarınız\u00a0iptal edilecektir.
+
+[account.profile.delete_mfa_error]
+original=Please enter the 6-digit code generated by your authenticator app to confirm account deletion.
+translation=Hesap silme işlemini onaylamak için lütfen kimlik doğrulama uygulamanız tarafından oluşturulan 6 haneli kodu girin.
+
+[account.profile.delete_no_refunds]
+original=Payments associated with your account will not be eligible for refunds.
+translation=Hesabınızla ilişkili ödemeler için iade yapılmayacaktır.
+
+[account.profile.delete_password_error]
+original=Please enter your password to confirm account deletion.
+translation=Hesap silme işlemini onaylamak için lütfen şifrenizi girin.
+
+[account.profile.delete_subscriptions_terminated]
+original=Your subscriptions to Obsidian Publish and Obsidian Sync will be\u00a0terminated.
+translation=Obsidian Publish ve Obsidian Sync abonelikleriniz\u00a0sonlandırılacaktır.
+
+[account.profile.delete_success]
+original=Your account is now deleted!
+translation=Hesabınız başarıyla silindi!
+
+[account.profile.disable]
+original=Disable
+translation=Devre dışı bırak
+
+[account.profile.email]
+original=Email
+translation=E-posta
+
+[account.profile.email_empty_error]
+original=New email cannot be empty.
+translation=Yeni e-posta alanı boş bırakılamaz.
+
+[account.profile.email_update_success]
+original=Your email has been successfully updated!
+translation=E-posta adresiniz başarıyla güncellendi!
+
+[account.profile.email_us]
+original=Email us
+translation=Bize e-posta gönderin
+
+[account.profile.enable]
+original=Enable
+translation=Etkinleştir
+
+[account.profile.log_out]
+original=Log out
+translation=Çıkış yap
+
+[account.profile.log_out_everywhere]
+original=Log out everywhere
+translation=Tüm cihazlardan çıkış yap
+
+[account.profile.log_out_everywhere_desc]
+original=Log out on all devices for security reasons. You will need to log in again on each\u00a0device.
+translation=Güvenlik nedeniyle tüm cihazlarda çıkış yapın. Her\u00a0cihazda yeniden giriş yapmanız gerekecektir.
+
+[account.profile.log_out_everywhere_title]
+original=Log out everywhere
+translation=Tüm cihazlardan çıkış yap
+
+[account.profile.logout_password_error]
+original=You must enter your current password to confirm.
+translation=Onaylamak için mevcut şifrenizi girmelisiniz.
+
+[account.profile.logout_warning]
+original=Any devices currently logged into your Obsidian account will lose their connection.
+translation=Obsidian hesabınıza o sırada bağlı olan tüm cihazların bağlantısı kesilecektir.
+
+[account.profile.mfa]
+original=2-factor authentication
+translation=İki adımlı doğrulama
+
+[account.profile.mfa_complete_setup]
+original=Complete set up
+translation=Kurulumu tamamla
+
+[account.profile.mfa_confirm_email_change]
+original=Please enter the 6-digit code generated by your authenticator app to confirm email change.
+translation=E-posta değişikliğini onaylamak için lütfen kimlik doğrulama uygulamanız tarafından oluşturulan 6 haneli kodu girin.
+
+[account.profile.mfa_copied]
+original=Copied!
+translation=Kopyalandı!
+
+[account.profile.mfa_copy_codes]
+original=Copy Recovery Codes
+translation=Kurtarma Kodlarını Kopyala
+
+[account.profile.mfa_desc]
+original=Protect your account with a second verification\u00a0step.
+translation=İkinci bir doğrulama\u00a0adımıyla hesabınızı koruyun.
+
+[account.profile.mfa_disable]
+original=Disable 2FA
+translation=2FA'yı Devre Dışı Bırak
+
+[account.profile.mfa_disable_code_error]
+original=Please enter the 6-digit code generated by your authenticator app to disable 2FA.
+translation=2FA'yı devre dışı bırakmak için lütfen kimlik doğrulama uygulamanız tarafından oluşturulan 6 haneli kodu girin.
+
+[account.profile.mfa_disable_password_error]
+original=Please enter your password to confirm disabling 2FA.
+translation=2FA'yı devre dışı bırakmak için lütfen şifrenizi girin.
+
+[account.profile.mfa_disable_recovery_error]
+original=Please enter an unused recovery code to disable 2FA.
+translation=2FA'yı devre dışı bırakmak için lütfen kullanılmamış bir kurtarma kodu girin.
+
+[account.profile.mfa_disable_title]
+original=Disable 2-factor authentication
+translation=İki adımlı doğrulamayı devre dışı bırak
+
+[account.profile.mfa_disabled_desc]
+original=You have successfully disabled 2-factor authentication on your account.
+translation=Hesabınızdaki iki adımlı doğrulamayı başarıyla devre dışı bıraktınız.
+
+[account.profile.mfa_disabled_title]
+original=2-factor authentication is disabled
+translation=İki adımlı doğrulama devre dışı bırakıldı
+
+[account.profile.mfa_download_codes]
+original=Download Recovery Codes
+translation=Kurtarma Kodlarını İndir
+
+[account.profile.mfa_enable_code_error]
+original=Please enter the 6-digit code generated by your authenticator app to enable 2FA.
+translation=2FA'yı etkinleştirmek için lütfen kimlik doğrulama uygulamanız tarafından oluşturulan 6 haneli kodu girin.
+
+[account.profile.mfa_enable_password_error]
+original=Please enter your password to enable 2FA.
+translation=2FA'yı etkinleştirmek için lütfen şifrenizi girin.
+
+[account.profile.mfa_enable_title]
+original=Enable 2-factor authentication
+translation=İki adımlı doğrulamayı etkinleştir
+
+[account.profile.mfa_enabled_desc]
+original=2FA is enabled for your account.
+translation=Hesabınız için 2FA etkinleştirildi.
+
+[account.profile.mfa_enabled_success]
+original=You have successfully set up 2FA to protect your account!
+translation=Hesabınızı korumak için 2FA'yı başarıyla kurdunuz!
+
+[account.profile.mfa_enabled_title]
+original=2-factor authentication is ready
+translation=İki adımlı doğrulama hazır
+
+[account.profile.mfa_enter_code]
+original=Enter the 6 digit code generated by your authenticator app
+translation=Kimlik doğrulama uygulamanız tarafından oluşturulan 6 haneli kodu girin
+
+[account.profile.mfa_enter_password]
+original=Enter your current password to confirm
+translation=Onaylamak için mevcut şifrenizi girin
+
+[account.profile.mfa_label_2fa_code]
+original=6-digit 2FA code
+translation=6 haneli 2FA kodu
+
+[account.profile.mfa_recovery_codes_desc]
+original=We strongly recommend storing these recovery codes in a safe place. Each code may be used once.
+translation=Bu kurtarma kodlarını güvenli bir yerde saklamanızı önemle tavsiye ederiz. Her kod bir kez kullanılabilir.
+
+[account.profile.mfa_refresh]
+original=Refresh
+translation=Yenile
+
+[account.profile.mfa_refresh_code_error]
+original=Please enter the 6-digit code generated by your authenticator app to refresh your recovery codes.
+translation=Kurtarma kodlarınızı yenilemek için lütfen kimlik doğrulama uygulamanız tarafından oluşturulan 6 haneli kodu girin.
+
+[account.profile.mfa_refresh_codes]
+original=Refresh\u00a0recovery\u00a0codes.
+translation=Kurtarma\u00a0kodlarını\u00a0yenileyin.
+
+[account.profile.mfa_refresh_password_error]
+original=Please enter your password to confirm refreshing your recovery codes.
+translation=Kurtarma kodlarınızı yenilemeyi onaylamak için lütfen şifrenizi girin.
+
+[account.profile.mfa_refresh_recovery_error]
+original=Please enter an unused recovery code to refresh your recovery codes.
+translation=Kurtarma kodlarınızı yenilemek için lütfen kullanılmamış bir kurtarma kodu girin.
+
+[account.profile.mfa_refresh_title]
+original=Refresh 2-factor authentication recovery codes
+translation=İki adımlı doğrulama kurtarma kodlarını yenileyin
+
+[account.profile.mfa_refreshed_desc]
+original=You have successfully refreshed your 2FA recovery codes. Any previously unused codes will no longer be accepted.
+translation=2FA kurtarma kodlarınızı başarıyla yenilediniz. Daha önce kullanılmamış olan kodlar artık kabul edilmeyecektir.
+
+[account.profile.mfa_refreshed_title]
+original=2-factor authentication recovery codes refreshed
+translation=İki adımlı doğrulama kurtarma kodları yenilendi
+
+[account.profile.mfa_step1_desc]
+original=Download and install an authenticator app on your phone, such as Google Authenticator or\u00a0Authy.
+translation=Telefonunuza Google Authenticator veya\u00a0Authy gibi bir kimlik doğrulama uygulaması indirin ve kurun.
+
+[account.profile.mfa_step1_title]
+original=Step 1: Download an authenticator app
+translation=1. Adım: Bir kimlik doğrulama uygulaması indirin
+
+[account.profile.mfa_step2_desc]
+original=Scan the QR code below with your authenticator app, or use the setup key below.
+translation=Aşağıdaki QR kodunu kimlik doğrulama uygulamanızla tarayın veya aşağıdaki kurulum anahtarını kullanın.
+
+[account.profile.mfa_step2_title]
+original=Step 2: Scan the QR code
+translation=2. Adım: QR kodunu tarayın
+
+[account.profile.mfa_step3_title]
+original=Step 3: Verify your code
+translation=3. Adım: Kodunuzu doğrulayın
+
+[account.profile.mfa_step4_title]
+original=Step 4: Enter your current password to confirm
+translation=4. Adım: Onaylamak için mevcut şifrenizi girin
+
+[account.profile.mfa_verify_desc]
+original=Verify your identity by entering your current password and 6-digit verification code from your authenticator app.
+translation=Mevcut şifrenizi ve kimlik doğrulama uygulamanızdaki 6 haneli doğrulama kodunu girerek kimliğinizi doğrulayın.
+
+[account.profile.name]
+original=Name
+translation=İsim
+
+[account.profile.name_empty_error]
+original=New name cannot be empty.
+translation=Yeni isim alanı boş bırakılamaz.
+
+[account.profile.name_update_success]
+original=Your name has been successfully updated!
+translation=Adınız başarıyla güncellendi!
+
+[account.profile.nav_label]
+original=Profile
+translation=Profil
+
+[account.profile.new_email]
+original=New email
+translation=Yeni e-posta
+
+[account.profile.new_name]
+original=New name
+translation=Yeni isim
+
+[account.profile.new_password]
+original=New password
+translation=Yeni şifre
+
+[account.profile.new_password_empty_error]
+original=New password cannot be empty.
+translation=Yeni şifre alanı boş bırakılamaz.
+
+[account.profile.password]
+original=Password
+translation=Şifre
+
+[account.profile.password_desc]
+original=Change your account\u00a0password.
+translation=Hesap\u00a0şifrenizi değiştirin.
+
+[account.profile.password_empty_error]
+original=Password cannot be empty.
+translation=Şifre alanı boş bırakılamaz.
+
+[account.profile.password_update_success]
+original=Your password has been successfully updated!
+translation=Şifreniz başarıyla güncellendi!
+
+[account.profile.placeholder_email_confirm]
+original=Enter email to confirm...
+translation=Onaylamak için e-postayı girin...
+
+[account.profile.placeholder_mfa_code]
+original=Enter 6-digit code...
+translation=6 haneli kodu girin...
+
+[account.profile.placeholder_new_email]
+original=Enter your new email address...
+translation=Yeni e-posta adresinizi girin...
+
+[account.profile.placeholder_new_name]
+original=Enter your new name...
+translation=Yeni adınızı girin...
+
+[account.profile.placeholder_new_password]
+original=Enter your new password...
+translation=Yeni şifrenizi girin...
+
+[account.profile.placeholder_old_password]
+original=Enter your old password...
+translation=Eski şifrenizi girin...
+
+[account.profile.placeholder_password]
+original=Enter your password...
+translation=Şifrenizi girin...
+
+[account.profile.placeholder_password_confirm]
+original=Enter password to confirm...
+translation=Onaylamak için şifreyi girin...
+
+[account.profile.title]
+original=Your profile
+translation=Profiliniz
+
+[account.profile.try_again_later]
+original=Please try again later.
+translation=Lütfen daha sonra tekrar deneyin.
+
+[account.publish.active]
+original=Active
+translation=Aktif
+
+[account.publish.auto_renewal]
+original=Auto-renewal
+translation=Otomatik yenileme
+
+[account.publish.buy_publish]
+original=Buy Publish
+translation=Publish Satın Al
+
+[account.publish.change_sites]
+original=Change sites
+translation=Siteleri değiştir
+
+[account.publish.change_success]
+original=Your Publish plan has been successfully updated.
+translation=Publish planınız başarıyla güncellendi.
+
+[account.publish.early_bird]
+original=Early bird
+translation=Erken kayıt
+
+[account.publish.early_bird_promo]
+original=20% lower price
+translation=%20 daha düşük fiyat
+
+[account.publish.invite_accept_error]
+original=Couldn’t accept invite
+translation=Davet kabul edilemedi
+
+[account.publish.invite_accept_error_desc]
+original=Unfortunately, something went wrong when accepting the invite.
+translation=Maalesef davet kabul edilirken bir şeyler yanlış gitti.
+
+[account.publish.invite_accepted]
+original=Accepted invite
+translation=Davet kabul edildi
+
+[account.publish.invite_accepted_desc]
+original=You have successfully accepted the invite!
+translation=Daveti başarıyla kabul ettiniz!
+
+[account.publish.invite_accepted_info]
+original=You can now go into the Obsidian app, log in under Settings -> Account, and enable the "Publish" core plugin to start collaborating on this site.
+translation=Artık Obsidian uygulamasına gidebilir, Ayarlar -> Hesap altından giriş yapabilir ve bu sitede iş birliği yapmaya başlamak için "Publish" yerleşik eklentisini etkinleştirebilirsiniz.
+
+[account.publish.invite_desc]
+original=You’ve been invited to a shared Obsidian Publish site!
+translation=Paylaşılan bir Obsidian Publish sitesine davet edildiniz!
+
+[account.publish.invite_instructions]
+original=If Obsidian didn’t open automatically, you can view sites shared with you by going to Publish → Switch site.
+translation=Obsidian otomatik olarak açılmadıysa Publish → Site değiştir seçeneğine giderek sizinle paylaşılan siteleri görüntüleyebilirsiniz.
+
+[account.publish.invite_title]
+original=Invited to shared Obsidian Publish site
+translation=Paylaşılan Obsidian Publish sitesine davet edildiniz
+
+[account.publish.learn_more]
+original=Learn\u00a0more.
+translation=Daha\u00a0fazla\u00a0bilgi\u00a0edinin.
+
+[account.publish.monthly]
+original=Monthly
+translation=Aylık
+
+[account.publish.next_renewal]
+original=Your next renewal will be for {{sites}} on {{date}}.
+translation=Bir sonraki yenilemeniz {{date}} tarihinde {{sites}} için olacaktır.
+
+[account.publish.not_renewed]
+original=Your plan will not be renewed.
+translation=Planınız yenilenmeyecektir.
+
+[account.publish.open_obsidian]
+original=Open Obsidian
+translation=Obsidian'ı Aç
+
+[account.publish.price_monthly]
+original=per month, per site, billed monthly
+translation=site başına, aylık faturalandırılır, aylık
+
+[account.publish.price_yearly]
+original=per month, per site, billed yearly
+translation=site başına, yıllık faturalandırılır, aylık
+
+[account.publish.publish_desc]
+original=Web hosting for your Obsidian notes. Create an online wiki, knowledge base, documentation, or digital garden. Hassle-free refund within 7 days.
+translation=Obsidian notlarınız için web barındırma hizmeti. Çevrimiçi bir wiki, bilgi tabanı, dokümantasyon veya dijital bahçe oluşturun. 7 gün içinde sorunsuz iade.
+
+[account.publish.publish_expire]
+original=Your Publish subscription will expire on {{date}}.
+translation=Publish aboneliğinizin süresi {{date}} tarihinde dolacaktır.
+
+[account.publish.purchase_success]
+original=Your Publish plan is now active! To start publishing your notes, follow our guide.
+translation=Publish planınız artık aktif! Notlarınızı yayınlamaya başlamak için rehberimizi takip edin.
+
+[account.publish.renew_monthly]
+original=Renew monthly
+translation=Aylık yenile
+
+[account.publish.renew_yearly]
+original=Renew yearly
+translation=Yıllık yenile
+
+[account.publish.renewal_frequency]
+original=Renewal frequency
+translation=Yenileme sıklığı
+
+[account.publish.save_yearly]
+original=Save 20% by switching to yearly renewal.
+translation=Yıllık yenilemeye geçerek %20 tasarruf edin.
+
+[account.publish.saving_yearly]
+original=You’re saving 20% compared to monthly renewal.
+translation=Aylık yenilemeye kıyasla %20 tasarruf ediyorsunuz.
+
+[account.publish.site_count]
+original={{count}} sites
+translation={{count}} site
+
+[account.publish.site_count_one]
+original=1 site
+translation=1 site
+
+[account.publish.stop]
+original=Stop
+translation=Durdur
+
+[account.publish.stop_auto_renewal]
+original=Stop auto-renewal
+translation=Otomatik yenilemeyi durdur
+
+[account.publish.stop_confirm]
+original=Are you sure you want to stop renewing your Obsidian Publish subscription?
+translation=Obsidian Publish aboneliğinizi yenilemeyi durdurmak istediğinizden emin misiniz?
+
+[account.publish.stop_renewing]
+original=Stop renewing Obsidian Publish
+translation=Obsidian Publish yenilemesini durdur
+
+[account.publish.stop_warning]
+original=Your Obsidian Publish subscription will expire on {{date}}. Your site will be deactivated on this date, and your data will be deleted from our servers 30 days later.
+translation=Obsidian Publish aboneliğiniz {{date}} tarihinde sona erecektir. Siteniz bu tarihte devre dışı bırakılacak ve verileriniz 30 gün sonra sunucularımızdan silinecektir.
+
+[account.publish.switch_to_monthly]
+original=Switch to monthly
+translation=Aylık ödemeye geç
+
+[account.publish.switch_to_yearly]
+original=Switch to yearly
+translation=Yıllık ödemeye geç
+
+[account.publish.title]
+original=Publish
+translation=Publish
+
+[account.publish.user_guide_desc]
+original=To publish files to your site, log in to your account in Obsidian and enable the Publish plugin.
+translation=Sitenizde dosya yayınlamak için Obsidian'da hesabınıza giriş yapın ve Publish eklentisini etkinleştirin.
+
+[account.publish.user_guide_link]
+original=See\u00a0user\u00a0guide.
+translation=Kullanıcı\u00a0rehberine göz atın.
+
+[account.publish.yearly]
+original=Yearly
+translation=Yıllık
+
+[account.publish.your_sites]
+original=Your sites
+translation=Siteleriniz
+
+[account.sync.active]
+original=Active
+translation=Aktif
+
+[account.sync.auto_renewal]
+original=Auto-renewal
+translation=Otomatik yenileme
+
+[account.sync.buy_sync]
+original=Buy Sync
+translation=Sync Satın Al
+
+[account.sync.change_plan]
+original=Change plan
+translation=Planı değiştir
+
+[account.sync.change_success]
+original=Your Sync plan has been successfully updated. Your new plan details may take up to 30 minutes to be applied.
+translation=Sync planınız başarıyla güncellendi. Yeni plan ayrıntılarınızın uygulanması 30 dakika kadar sürebilir.
+
+[account.sync.early_bird]
+original=Early bird
+translation=Erken kayıt
+
+[account.sync.invite_accept_error]
+original=Couldn’t accept invite
+translation=Davet kabul edilemedi
+
+[account.sync.invite_accept_error_desc]
+original=Unfortunately, something went wrong when accepting the invite.
+translation=Maalesef davet kabul edilirken bir şeyler yanlış gitti.
+
+[account.sync.invite_accepted]
+original=Accepted invite
+translation=Davet kabul edildi
+
+[account.sync.invite_accepted_desc]
+original=You have successfully accepted the invite!
+translation=Daveti başarıyla kabul ettiniz!
+
+[account.sync.invite_accepted_info]
+original=You can now go in to the Obsidian app, log in under Settings -> Account, and enable the "Sync" core plugin to start collaborating on this vault.
+translation=Artık Obsidian uygulamasına gidebilir, Ayarlar -> Hesap altından giriş yapabilir ve bu kasada iş birliği yapmaya başlamak için "Sync" yerleşik eklentisini etkinleştirebilirsiniz.
+
+[account.sync.invite_desc]
+original=You’ve been invited to a shared Obsidian Sync vault!
+translation=Paylaşılan bir Obsidian Sync kasasına davet edildiniz!
+
+[account.sync.invite_instructions]
+original=If Obsidian didn’t open automatically, you can view vaults shared with you by going to Settings → Sync → Remote vault → Manage/Choose.
+translation=Obsidian otomatik olarak açılmadıysa Ayarlar → Sync → Uzak kasa → Yönet/Seç bölümüne giderek sizinle paylaşılan kasaları görüntüleyebilirsiniz.
+
+[account.sync.invite_title]
+original=Invited to shared Obsidian Sync vault
+translation=Paylaşılan Obsidian Sync kasasına davet edildiniz
+
+[account.sync.learn_more]
+original=Learn\u00a0more.
+translation=Daha\u00a0fazla\u00a0bilgi\u00a0edinin.
+
+[account.sync.monthly]
+original=Monthly
+translation=Aylık
+
+[account.sync.next_renewal]
+original=Your next renewal will be on {{date}}.
+translation=Bir sonraki yenilemeniz {{date}} tarihinde olacaktır.
+
+[account.sync.not_renewed]
+original=Your plan will not be renewed.
+translation=Planınız yenilenmeyecektir.
+
+[account.sync.open_obsidian]
+original=Open Obsidian
+translation=Open Obsidian
+
+[account.sync.plan]
+original=Plan
+translation=Plan
+
+[account.sync.plan_100gb]
+original=100 GB total storage
+translation=Toplam 100 GB depolama alanı
+
+[account.sync.plan_10_vaults]
+original=10 vaults
+translation=10 kasa
+
+[account.sync.plan_10gb]
+original=10 GB total storage
+translation=Toplam 10 GB depolama alanı
+
+[account.sync.plan_12months]
+original=12 months history
+translation=12 aylık geçmiş
+
+[account.sync.plan_1_vault]
+original=1 vault
+translation=1 kasa
+
+[account.sync.plan_1gb]
+original=1 GB total storage
+translation=Toplam 1 GB depolama alanı
+
+[account.sync.plan_1month]
+original=1 month history
+translation=1 aylık geçmiş
+
+[account.sync.plan_200mb]
+original=200 MB max file size
+translation=200 MB maksimum dosya boyutu
+
+[account.sync.plan_50gb_early]
+original=50 GB total storage (early supporter)
+translation=50 GB toplam depolama (erken dönem destekçisi)
+
+[account.sync.plan_5mb]
+original=5 MB max file size
+translation=5 MB maksimum dosya boyutu
+
+[account.sync.plan_plus]
+original=Sync Plus
+translation=Sync Plus
+
+[account.sync.plan_shared]
+original=Shared vaults
+translation=Paylaşılan kasalar
+
+[account.sync.plan_standard]
+original=Sync Standard
+translation=Sync Standard
+
+[account.sync.plan_unlimited]
+original=Unlimited devices
+translation=Sınırsız cihaz
+
+[account.sync.plan_upgrade_basic]
+original=Upgrade your plan to increase the number of vaults and storage limits.
+translation=Kasa sayısını ve depolama sınırlarını artırmak için planınızı yükseltin.
+
+[account.sync.plan_upgrade_legacy]
+original=Keep your subscription active to maintain your early supporter perks. You can also upgrade to access 100 GB of storage.
+translation=Erken dönem destekçi avantajlarınızı korumak için aboneliğinizi aktif tutun. Ayrıca 100 GB depolama alanına erişmek için planınızı yükseltebilirsiniz.
+
+[account.sync.plan_upgrade_standard]
+original=Upgrade your plan to increase total storage to 100 GB.
+translation=Toplam depolama alanını 100 GB'a çıkarmak için planınızı yükseltin.
+
+[account.sync.price_monthly]
+original=per month, billed monthly
+translation=aylık faturalandırılır, aylık
+
+[account.sync.price_yearly]
+original=per month, billed yearly
+translation=yıllık faturalandırılır, aylık
+
+[account.sync.purchase_success]
+original=Your Sync plan is now active! Open Obsidian to start syncing your notes.
+translation=Sync planınız artık aktif! Notlarınızı senkronize etmeye başlamak için Obsidian'ı açın.
+
+[account.sync.purchase_success_guide]
+original=Need help? Follow our guide.
+translation=Yardıma mı ihtiyacınız var? Rehberimizi takip edin.
+
+[account.sync.renew_monthly]
+original=Renew monthly
+translation=Aylık yenile
+
+[account.sync.renew_yearly]
+original=Renew yearly
+translation=Yıllık yenile
+
+[account.sync.renewal_frequency]
+original=Renewal frequency
+translation=Yenileme sıklığı
+
+[account.sync.save_yearly]
+original=Save 20% by switching to yearly renewal.
+translation=Yıllık yenilemeye geçerek %20 tasarruf edin.
+
+[account.sync.saving_yearly]
+original=You’re saving 20% compared to monthly renewal.
+translation=Aylık yenilemeye kıyasla %20 tasarruf ediyorsunuz.
+
+[account.sync.stop]
+original=Stop
+translation=Durdur
+
+[account.sync.stop_auto_renewal]
+original=Stop auto-renewal
+translation=Otomatik yenilemeyi durdur
+
+[account.sync.stop_confirm]
+original=Are you sure you want to stop renewing your Obsidian Sync subscription?
+translation=Obsidian Sync aboneliğinizi yenilemeyi durdurmak istediğinizden emin misiniz?
+
+[account.sync.stop_legacy_warning]
+original=You are on a legacy plan with 50 GB storage. Once your subscription expires you will no longer be able to sign up for this plan.
+translation=50 GB depolama alanına sahip eski bir plandasınız. Aboneliğinizin süresi dolduğunda bu plana tekrar kaydolamazsınız.
+
+[account.sync.stop_renewing]
+original=Stop renewing Obsidian Sync
+translation=Obsidian Sync yenilemesini durdur
+
+[account.sync.stop_warning]
+original=Your Obsidian Sync subscription will expire on {{date}}. Your data will be deleted from our servers 30 days after your subscription expires.
+translation=Obsidian Sync aboneliğiniz {{date}} tarihinde sona erecektir. Verileriniz, aboneliğinizin süresi dolduktan 30 gün sonra sunucularımızdan silinecektir.
+
+[account.sync.switch_to_monthly]
+original=Switch to monthly
+translation=Aylık ödemeye geç
+
+[account.sync.switch_to_yearly]
+original=Switch to yearly
+translation=Yıllık ödemeye geç
+
+[account.sync.sync_desc]
+original=Sync your notes across devices with end-to-end encryption. Hassle-free refund within 7 days.
+translation=Uçtan uca şifreleme ile notlarınızı cihazlar arasında senkronize edin. 7 gün içinde sorunsuz iade.
+
+[account.sync.sync_expire]
+original=Your Sync subscription will expire on {{date}}.
+translation=Sync aboneliğinizin süresi {{date}} tarihinde dolacaktır.
+
+[account.sync.title]
+original=Sync
+translation=Sync
+
+[account.sync.unknown_plan]
+original=Unknown sync plan. Please contact support
+translation=Bilinmeyen sync planı. Lütfen destek ekibiyle iletişime geçin
+
+[account.sync.upgrade_plan]
+original=Upgrade plan
+translation=Planı yükselt
+
+[account.sync.user_guide_desc]
+original=To start syncing, log in to your account in Obsidian and enable the Sync plugin.
+translation=Senkronizasyonu başlatmak için Obsidian'da hesabınıza giriş yapın ve Sync eklentisini etkinleştirin.
+
+[account.sync.user_guide_link]
+original=See\u00a0user\u00a0guide.
+translation=Kullanıcı\u00a0rehberine göz atın.
+
+[account.sync.yearly]
+original=Yearly
+translation=Yıllık
+
+[auth.already_have_account]
+original=Already have an account?
+translation=Zaten bir hesabınız var mı?
+
+[auth.back_to_account]
+original=Back to account
+translation=Hesaba geri dön
+
+[auth.back_to_sign_in]
+original=Back to sign in
+translation=Giriş yapmaya geri dön
+
+[auth.create_account]
+original=Create an\u00a0account
+translation=Bir\u00a0hesap\u00a0oluşturun
+
+[auth.create_account_link]
+original=Create an account
+translation=Hesap oluştur
+
+[auth.didnt_receive_email]
+original=Didn’t receive email?
+translation=E-posta almadınız mı?
+
+[auth.dont_have_account]
+original=Don’t have an account?
+translation=Hesabınız yok mu?
+
+[auth.email]
+original=Email
+translation=E-posta
+
+[auth.email_empty]
+original=Email cannot be empty.
+translation=E-posta alanı boş bırakılamaz.
+
+[auth.email_invalid]
+original=Email is not valid.
+translation=E-posta adresi geçerli değil.
+
+[auth.email_invalid_at]
+original=Email address is not valid and must contain "@".
+translation=E-posta adresi geçerli değil ve "@" içermelidir.
+
+[auth.fill_email]
+original=Please fill out your email.
+translation=Lütfen e-posta adresinizi doldurun.
+
+[auth.forgot_password]
+original=Forgot password?
+translation=Şifrenizi mi unuttunuz?
+
+[auth.full_name]
+original=Full name
+translation=Ad soyad
+
+[auth.mfa_code]
+original=2-factor authentication code
+translation=İki adımlı doğrulama kodu
+
+[auth.name_empty]
+original=Name cannot be empty.
+translation=İsim alanı boş bırakılamaz.
+
+[auth.new_password]
+original=New password
+translation=Yeni şifre
+
+[auth.password]
+original=Password
+translation=Şifre
+
+[auth.password_empty]
+original=Password cannot be empty.
+translation=Şifre alanı boş bırakılamaz.
+
+[auth.password_set_success]
+original=Your password has been successfully set.
+translation=Şifreniz başarıyla belirlendi.
+
+[auth.please_log_in]
+original=Please log in first.
+translation=Lütfen önce giriş yapın.
+
+[auth.please_log_in_invite]
+original=Please log in or sign up to accept the invite.
+translation=Daveti kabul etmek için lütfen giriş yapın veya kaydolun.
+
+[auth.please_log_in_redeem]
+original=Please log in or sign up to redeem your gift.
+translation=Hediyenizi kullanmak için lütfen giriş yapın veya kaydolun.
+
+[auth.please_set_password]
+original=Please set a new password.
+translation=Lütfen yeni bir şifre belirleyin.
+
+[auth.recovery_code]
+original=Recovery code
+translation=Kurtarma kodu
+
+[auth.resend]
+original=Resend
+translation=Yeniden gönder
+
+[auth.reset]
+original=Reset
+translation=Sıfırla
+
+[auth.reset_password]
+original=Reset your password
+translation=Şifrenizi sıfırlayın
+
+[auth.reset_password_btn]
+original=Reset password
+translation=Şifreyi sıfırla
+
+[auth.reset_password_sent]
+original=We have sent an email to {{email}} to reset your password.
+translation=Şifrenizi sıfırlamanız için {{email}} adresine bir e-posta gönderdik.
+
+[auth.set_new_password]
+original=Set a new password
+translation=Yeni şifre belirleyin
+
+[auth.sign_in]
+original=Sign in
+translation=Giriş yap
+
+[auth.sign_in_link]
+original=Sign in
+translation=Giriş yap
+
+[auth.sign_in_title]
+original=Sign in to your account
+translation=Hesabınıza giriş yapın
+
+[auth.sign_up]
+original=Sign up
+translation=Kaydol
+
+[auth.signup_desc]
+original=An Obsidian account allows you to purchase licenses and add-on services. Creating an account is not required to download or use the\u00a0app.
+translation=Bir Obsidian hesabı, lisans ve ek hizmetler satın almanızı sağlar. Uygulamayı indirmek veya kullanmak için hesap oluşturmak zorunlu\u00a0değindir.
+
+[auth.signup_success]
+original=Success! You will receive an email soon to confirm your email address.
+translation=Başarılı! E-posta adresinizi onaylamanız için kısa süre içinde bir e-posta alacaksınız.
+
+[auth.something_went_wrong]
+original=Something went wrong, please try again later.
+translation=Bir şeyler yanlış gitti, lütfen daha sonra tekrar deneyin.
+
+[auth.use_recovery_code]
+original=Use recovery code
+translation=Kurtarma kodu kullan
+
+[brand.bluesky]
+original=Bluesky
+translation=Bluesky
+
+[brand.canvas]
+original=Canvas
+translation=Canvas
+
+[brand.catalyst]
+original=Catalyst
+translation=Catalyst
+
+[brand.cli]
+original=CLI
+translation=CLI
+
+[brand.commercial]
+original=Commercial
+translation=Ticari
+
+[brand.discord]
+original=Discord
+translation=Discord
+
+[brand.github]
+original=GitHub
+translation=GitHub
+
+[brand.headless_sync]
+original=Headless Sync
+translation=Headless Sync
+
+[brand.mastodon]
+original=Mastodon
+translation=Mastodon
+
+[brand.mobile]
+original=Mobile
+translation=Mobil
+
+[brand.obsidian]
+original=Obsidian
+translation=Obsidian
+
+[brand.obsidian_cli]
+original=Obsidian CLI
+translation=Obsidian CLI
+
+[brand.obsidian_publish]
+original=Obsidian Publish
+translation=Obsidian Publish
+
+[brand.obsidian_sync]
+original=Obsidian Sync
+translation=Obsidian Sync
+
+[brand.obsidian_web_clipper]
+original=Obsidian Web Clipper
+translation=Obsidian Web Clipper
+
+[brand.publish]
+original=Publish
+translation=Publish
+
+[brand.sync]
+original=Sync
+translation=Sync
+
+[brand.threads]
+original=Threads
+translation=Threads
+
+[brand.twitter]
+original=Twitter
+translation=Twitter
+
+[brand.web_clipper]
+original=Web Clipper
+translation=Web Clipper
+
+[brand.youtube]
+original=YouTube
+translation=YouTube
+
+[buy.catalyst.choose_tier]
+original=Choose a tier
+translation=Bir seviye seçin
+
+[buy.catalyst.community_badge]
+original=community badge
+translation=topluluk rozeti
+
+[buy.catalyst.early_access]
+original=Early access to beta versions
+translation=Beta sürümlerine erken erişim
+
+[buy.catalyst.exclusive_discord]
+original=Exclusive Discord channel
+translation=Özel Discord kanalı
+
+[buy.catalyst.insider_badge]
+original=Insider
+translation=Insider
+
+[buy.catalyst.supporter_badge]
+original=Supporter
+translation=Destekçi
+
+[buy.catalyst.title]
+original=Become a Catalyst member
+translation=Catalyst üyesi olun
+
+[buy.catalyst.upgrade_desc]
+original=Select a tier to upgrade. When upgrading you only need to pay the difference.
+translation=Yükseltmek için bir seviye seçin. Yükseltme yaparken yalnızca aradaki farkı ödersiniz.
+
+[buy.catalyst.vip_badge]
+original=VIP
+translation=VIP
+
+[buy.credit.amount_label]
+original=Amount of credit to purchase (USD)
+translation=Satın alınacak kredi tutarı (USD)
+
+[buy.credit.credit_desc]
+original=Obsidian Credit can be used to pay for any Obsidian license or service. You can also send credit to anyone, such as friends, family, and coworkers.
+translation=Obsidian Kredisi, herhangi bir Obsidian lisansı veya hizmeti (Sync ve Publish dahil) için ödeme yapmak amacıyla kullanılabilir. Ayrıca krediyi arkadaşlarınız, aileniz ve iş arkadaşlarınız gibi herkese gönderebilirsiniz.
+
+[buy.credit.min_purchase]
+original=Minimum $5 credit purchase.
+translation=En az 5$ tutarında kredi satın alınmalıdır.
+
+[buy.credit.no_refund]
+original=Obsidian Credit is not eligible for refunds.
+translation=Obsidian Kredisi iade edilemez.
+
+[buy.credit.title]
+original=Add credit to your\u00a0account
+translation=Hesabınıza\u00a0kredi\u00a0ekleyin
+
+[buy.license.business_name_error]
+original=Please provide your business name.
+translation=Lütfen işletme adınızı belirtin.
+
+[buy.license.business_name_label]
+original=Business name
+translation=İşletme adı
+
+[buy.license.commercial_renew]
+original=Commercial licenses renew yearly.
+translation=Ticari lisanslar yıllık olarak yenilenir.
+
+[buy.license.current_seats_info]
+original=Your organization currently has {{seats}} {{seatWord}}. You can add or remove seats. Additional seats are pro-rated and will renew with your current {{seatWord}} on {{date}}. Any seats you remove can still be used until that\u00a0date.
+translation=Kuruluşunuzun şu anda {{seats}} {{seatWord}} bulunuyor. Kullanıcı ekleyebilir veya kaldırabilirsiniz. Eklenen kullanıcılar için ücret kıstelyevm (orantılı) olarak hesaplanır ve mevcut {{seatWord}} ile birlikte {{date}} tarihinde yenilenir. Kaldırdığınız kullanıcıları ise o\u00a0tarihe kadar kullanmaya devam edebilirsiniz.
+
+[buy.license.faq_link]
+original=See\u00a0our\u00a0FAQs.
+translation=Sıkça\u00a0sorulan\u00a0sorulara göz atın.
+
+[buy.license.org_desc]
+original=Your organization should have at least one seat per Obsidian user. Organizations with 25 licenses or more can be featured as a supporting organization.
+translation=Kuruluşunuzda her Obsidian kullanıcısı için en az bir kullanıcı (seat) bulunmalıdır. 25 veya daha fazla lisansa sahip kuruluşlar, öne çıkan destekçiler sayfamızda yer alabilir.
+
+[buy.license.questions]
+original=Questions? {{link}}
+translation=Sorularınız mı var? {{link}}
+
+[buy.license.reduce_seats]
+original=Reduce seats to {{count}}
+translation=Kullanıcı sayısını {{count}} kişiye düşür
+
+[buy.license.seat]
+original=seat
+translation=kullanıcı
+
+[buy.license.seats]
+original=seats
+translation=kullanıcı
+
+[buy.license.seats_label]
+original=Total number of seats
+translation=Toplam kullanıcı sayısı
+
+[buy.license.title]
+original=Commercial licenses
+translation=Ticari lisanslar
+
+[buy.publish.current_plan]
+original=Your current plan has {{sites}} {{siteWord}}.
+translation=Mevcut planınızda {{sites}} {{siteWord}} bulunuyor.
+
+[buy.publish.current_plan_renew]
+original=Your current plan has {{sites}} {{siteWord}} and is set to renew with {{renewSites}} {{renewSiteWord}}.
+translation=Mevcut planınızda {{sites}} {{siteWord}} bulunuyor ve {{renewSites}} {{renewSiteWord}} ile yenilenecek şekilde ayarlandı.
+
+[buy.publish.previous_plan]
+original=Your previous plan had {{sites}} {{siteWord}}.
+translation=Önceki planınızda {{sites}} {{siteWord}} bulunuyordu.
+
+[buy.publish.reduce_sites]
+original=Reduce sites
+translation=Siteleri azalt
+
+[buy.publish.site]
+original=site
+translation=site
+
+[buy.publish.sites]
+original=sites
+translation=site
+
+[buy.publish.sites_label]
+original=Number of sites
+translation=Site sayısı
+
+[buy.publish.title]
+original=Choose a Publish plan
+translation=Bir Publish planı seçin
+
+[buy.sync.basic_desc]
+original=1 synced vault · 1 month history
+translation=1 senkronize kasa · 1 aylık geçmiş
+
+[buy.sync.changes_immediate]
+original=Changes take effect immediately.
+translation=Değişiklikler hemen yürürlüğe girer.
+
+[buy.sync.choose_plan]
+original=Choose a Sync plan
+translation=Bir Sync planı seçin
+
+[buy.sync.downgrade]
+original=Downgrade immediately
+translation=Hemen alt plana geç
+
+[buy.sync.legacy_warning]
+original=You are currently on a discontinued plan. If you change plans you will no longer be able to select it.
+translation=Şu anda kullanımdan kaldırılmış bir plandasınız. Plan değiştirirseniz artık bu planı seçemezsiniz.
+
+[buy.sync.over_storage_error]
+original=You currently are using more storage the selected plan allows. Before you can change plans please use the Obsidian app to remove synced files you don’t need.
+translation=Şu anda seçilen planın izin verdiğinden daha fazla depolama alanı kullanıyorsunuz. Plan değiştirmeden önce lütfen Obsidian uygulamasını kullanarak ihtiyacınız olmayan senkronize edilmiş dosyaları kaldırın.
+
+[buy.sync.plan_label]
+original=Plan
+translation=Plan
+
+[buy.sync.plus_desc]
+original=10 synced vaults · 12 month history
+translation=10 senkronize kasa · 12 aylık geçmiş
+
+[buy.sync.pricing_page]
+original=pricing page
+translation=ücretlendirme sayfası
+
+[buy.sync.see_guide]
+original=See guide.
+translation=Rehbere göz atın.
+
+[buy.sync.see_pricing]
+original=See our {{link}} for details.
+translation=Detaylar için {{link}} göz atın.
+
+[buy.sync.storage_label]
+original=Storage
+translation=Depolama
+
+[buy.sync.too_many_vaults_error]
+original=You currently have too many remote vaults to switch to the selected plan. Before you can change plans please use the Obsidian app to remove synced vaults that you no longer need.
+translation=Şu anda seçilen plana geçmek için çok fazla uzak kasanız bulunuyor. Plan değiştirmeden önce lütfen Obsidian uygulamasını kullanarak artık ihtiyacınız olmayan senkronize edilmiş kasaları kaldırın.
+
+[checkout.address_error]
+original=Please complete your billing address.
+translation=Lütfen fatura adresinizi tamamlayın.
+
+[checkout.autofill_link]
+original=Autofill with Link
+translation=Link ile otomatik doldur
+
+[checkout.complete_payment]
+original=Complete your payment
+translation=Ödemenizi tamamlayın
+
+[checkout.contact_us]
+original=Contact us
+translation=İletişime geçin
+
+[checkout.pay_now]
+original=Pay now
+translation=Şimdi öde
+
+[checkout.pay_with_credit]
+original=Pay with credit
+translation=Kredi ile öde
+
+[checkout.payment_breadcrumb]
+original=Payment
+translation=Ödeme
+
+[checkout.payment_method]
+original=Payment method
+translation=Ödeme yöntemi
+
+[checkout.privacy_policy]
+original=Privacy policy
+translation=Gizlilik politikası
+
+[checkout.refund_policy]
+original=Refund policy
+translation=İade politikası
+
+[checkout.secure_encrypted]
+original=All transactions are secure and\u00a0encrypted.
+translation=Tüm işlemler güvenli ve\u00a0şifrelidir.
+
+[checkout.terms_charge]
+original=you allow Obsidian to charge you for future payments in accordance with our terms.
+translation=Obsidian'a, gelecekteki ödemeler için şartlarımıza uygun olarak sizden tahsilat yapma yetkisi vermiş olursunuz.
+
+[checkout.terms_credit]
+original=By paying with credit,
+translation=Krediyle ödeyerek,
+
+[checkout.terms_of_service]
+original=Terms of service
+translation=Hizmet şartları
+
+[checkout.terms_payment]
+original=By providing your payment information,
+translation=Ödeme bilgilerinizi sağlayarak,
+
+[checkout.terms_renews]
+original=Your subscription renews automatically until\u00a0canceled.
+translation=Aboneliğiniz, iptal edilene kadar otomatik olarak\u00a0yenilenir.
+
+[checkout.unexpected_error]
+original=An unexpected error occurred. Please try again.
+translation=Beklenmedik bir hata oluştu. Lütfen tekrar deneyin.
+
+[checkout.vat]
+original=VAT
+translation=KDV
+
+[checkout.vat_desc]
+original=Provide a VAT number if you are buying for an EU business. Your VAT will be calculated based on the billing address provided above. Your VAT number will be stored for future renewals and purchases.
+translation=Bir AB işletmesi için satın alıyorsanız KDV numarası belirtin. KDV'niz, yukarıda sağlanan fatura adresine göre hesaplanacaktır. KDV numaranız sonraki yenilemeler ve satın alımlar için saklanacaktır.
+
+[checkout.vat_number]
+original=VAT Number
+translation=KDV Numarası
+
+[checkout.your_details]
+original=Your details
+translation=Bilgileriniz
+
+[features.backlinks]
+original=Backlinks
+translation=Geri bağlantılar
+
+[features.collaboration]
+original=Collaboration
+translation=İş birliği
+
+[features.community_plugins]
+original=Community plugins
+translation=Topluluk eklentileri
+
+[features.custom_domain]
+original=Custom domain
+translation=Özel alan adı
+
+[features.file_recovery]
+original=File recovery
+translation=Dosya kurtarma
+
+[features.graph]
+original=Graph
+translation=Grafik
+
+[features.graph_view]
+original=Graph view
+translation=Grafik görünümü
+
+[features.hotkeys]
+original=Hotkeys
+translation=Kısayollar
+
+[features.hover_previews]
+original=Hover previews
+translation=Üzerine gelindiğinde önizleme
+
+[features.password]
+original=Password protection
+translation=Şifre koruması
+
+[features.plugins]
+original=Plugins
+translation=Eklentiler
+
+[features.selective_sync]
+original=Selective sync
+translation=Seçici senkronizasyon
+
+[features.shared_vaults]
+original=Shared vaults
+translation=Paylaşılan kasalar
+
+[features.stacked_pages]
+original=Stacked pages
+translation=Üst üste sayfalar
+
+[features.themes]
+original=Themes
+translation=Temalar
+
+[features.version_history]
+original=Version history
+translation=Sürüm geçmişi
+
+[nav.about]
+original=About
+translation=Hakkında
+
+[nav.account]
+original=Account
+translation=Hesap
+
+[nav.blog]
+original=Blog
+translation=Blog
+
+[nav.brand_guidelines]
+original=Brand guidelines
+translation=Marka yönergeleri
+
+[nav.changelog]
+original=Changelog
+translation=Değişiklik günlüğü
+
+[nav.community]
+original=Community
+translation=Topluluk
+
+[nav.developers]
+original=Developers
+translation=Geliştiriciler
+
+[nav.download]
+original=Download
+translation=İndir
+
+[nav.enterprise]
+original=Enterprise
+translation=Kurumsal
+
+[nav.follow_us]
+original=Follow us
+translation=Bizi takip edin
+
+[nav.forum]
+original=Forum
+translation=Forum
+
+[nav.get_started]
+original=Get started
+translation=Başlarken
+
+[nav.help]
+original=Help
+translation=Yardım
+
+[nav.learn]
+original=Learn
+translation=Öğrenin
+
+[nav.learn_more]
+original=Learn more
+translation=Daha fazla bilgi al
+
+[nav.license_overview]
+original=License overview
+translation=Lisans genel bakış
+
+[nav.merch_store]
+original=Merch store
+translation=Ürün mağazası
+
+[nav.overview]
+original=Overview
+translation=Genel Bakış
+
+[nav.plugins]
+original=Plugins
+translation=Eklentiler
+
+[nav.pricing]
+original=Pricing
+translation=Ücretlendirme
+
+[nav.privacy]
+original=Privacy
+translation=Gizlilik
+
+[nav.privacy_policy]
+original=Privacy policy
+translation=Gizlilik politikası
+
+[nav.resources]
+original=Resources
+translation=Kaynaklar
+
+[nav.roadmap]
+original=Roadmap
+translation=Yol haritası
+
+[nav.security]
+original=Security
+translation=Güvenlik
+
+[nav.system_status]
+original=System status
+translation=Sistem durumu
+
+[nav.terms_of_service]
+original=Terms of service
+translation=Hizmet şartları
+
+[pages.404.back]
+original=Back to the home\u00a0page.
+translation=Ana\u00a0sayfaya\u00a0geri\u00a0dön.
+
+[pages.404.subtitle]
+original=We’d make note of this, but we don’t track visitors. If something seems broken, {{link}}.
+translation=Bunu not ederdik ancak ziyaretçilerimizi takip etmiyoruz. Bir şeyler bozuk görünüyorsa {{link}}.
+
+[pages.404.subtitle_link]
+original=let us\u00a0know
+translation=bize\u00a0bildirin
+
+[pages.404.title]
+original=You found an unresolved\u00a0link.
+translation=Çözümlenmemiş bir\u00a0bağlantı buldunuz.
+
+[pages.about.about]
+original=About Obsidian
+translation=About Obsidian
+
+[pages.about.credits_desc]
+original=Obsidian is made possible by our amazing contributors and community of volunteers. See more on the {{link}} page.
+translation=Obsidian, harika katkıda bulunanlarımız ve gönüllü topluluğumuz sayesinde varlığını sürdürmektedir. Daha fazlasını {{link}} sayfasında görebilirsiniz.
+
+[pages.about.credits_link]
+original=Credits
+translation=Katkıda Bulunanlar
+
+[pages.about.durable]
+original=Durable
+translation=Kalıcı
+
+[pages.about.durable_desc]
+original=We believe that your data should be future-proof and easily accessible, no matter where you are. That’s why we use simple, open file formats that prevent lock-in and ensure that your data can be preserved for generations to\u00a0come.
+translation=Nerede olursanız olun, verilerinizin geleceğe hazır ve kolayca erişilebilir olması gerektiğine inanıyoruz. Bu nedenle, verilerinizin nesiller boyu korunabilmesini sağlayan ve kilitlenmeyi önleyen basit, açık dosya biçimleri kullanıyoruz.
+
+[pages.about.independent]
+original=Independent
+translation=Bağımsız
+
+[pages.about.independent_desc]
+original=We believe in staying true to these principles. That’s why we are 100% supported by our users, not\u00a0investors.
+translation=Bu ilkelere sadık kalmaya inanıyoruz. Bu nedenle yatırımcılar tarafından değil, %100 kullanıcılarımız tarafından destekleniyoruz.
+
+[pages.about.malleable]
+original=Malleable
+translation=Şekillendirilebilir
+
+[pages.about.malleable_desc]
+original=We believe that tools should adapt to your way of thinking, not the other way around. That’s why we design our tools to be highly customizable and extensible, so you can shape them to your unique\u00a0needs.
+translation=Araçların sizin düşünme şeklinize uyum sağlaması gerektiğine inanıyoruz, tersi değil. Bu nedenle araçlarımızı son derece özelleştirilebilir ve genişletilebilir şekilde tasarlıyoruz, böylece onları benzersiz ihtiyaçlarınıza göre şekillendirebilirsiniz.
+
+[pages.about.manifesto]
+original=Manifesto
+translation=Manifesto
+
+[pages.about.manifesto_desc]
+original=Our guiding principles are set in\u00a0stone.
+translation=Yol gösterici ilkelerimiz taşa kazınmıştır.
+
+[pages.about.meta_desc]
+original=Our guiding principles are set in stone: yours, durable, private, malleable, independent.
+translation=Yol gösterici ilkelerimiz taşa kazınmıştır: sizindir, kalıcıdır, özeldir, şekillendirilebilir ve bağımsızdır.
+
+[pages.about.private]
+original=Private
+translation=Gizli
+
+[pages.about.private_desc]
+original=We believe that your thoughts and ideas belong to you and deserve complete privacy. That’s why your data is stored on your device, inaccessible to us. When you use our online services, your data is protected with end-to-end encryption for maximum\u00a0security.
+translation=Düşüncelerinizin ve fikirlerinizin size ait olduğuna ve eksiksiz bir gizliliği hak ettiğine inanıyoruz. Bu nedenle verileriniz cihazınızda saklanır ve tarafımızdan erişilemez. Çevrimiçi hizmetlerimizi kullandığınızda verileriniz maksimum güvenlik için uçtan uca şifrelemeyle korunur.
+
+[pages.about.who_makes]
+original=Who makes Obsidian?
+translation=Obsidian'ı kim geliştiriyor?
+
+[pages.about.who_makes_desc]
+original=We’re a small team focused on helping you think\u00a0better.
+translation=Daha iyi düşünmenize yardımcı olmaya odaklanmış küçük bir ekibiz.
+
+[pages.about.yours]
+original=Yours
+translation=Sizin
+
+[pages.about.yours_desc]
+original=We believe that everyone should have the tools to think clearly and organize ideas effectively. That’s why our tools are free for all to\u00a0use.
+translation=Herkesin net düşünecek ve fikirleri etkili bir şekilde düzenleyecek araçlara sahip olması gerektiğine inanıyoruz. Bu nedenle araçlarımızın kullanımı herkes için ücretsizdir.
+
+[pages.blog.subtitle_desc]
+original=What’s new with Obsidian?
+translation=Obsidian'da yeni neler var?
+
+[pages.brand.contact_us_desc]
+original=The Obsidian name, logo and app icon are trademarks. You are free to customize the Obsidian app icon for your personal use. If you want to use Obsidian assets for commercial purposes, please {{link}}.
+translation=Obsidian adı, logosu ve uygulama simgesi ticari markalardır. Kişisel kullanımınız için Obsidian uygulama simgesini özelleştirmekte özgürsünüz. Obsidian varlıklarını ticari amaçlarla kullanmak istiyorsanız lütfen {{link}}.
+
+[pages.brand.guidelines]
+original=Guidelines
+translation=Yönergeler
+
+[pages.brand.guidelines_desc]
+original=The Obsidian logo is inspired by its namesake, the volcanic rock which has been used since the dawn of humanity to make arrowheads, scrapers, knives, and other tools. {{link}}
+translation=Obsidian logosu, insanlığın varoluşundan bu yana ok uçları, kazıyıcılar, bıçaklar ve diğer araçları yapmak için kullandığı volkanik cam olan adaşından esinlenmiştir. {{link}}
+
+[pages.brand.hero]
+original=Brand
+translation=Marka
+
+[pages.brand.hero_desc]
+original=Download the Obsidian logo and brand assets.
+translation=Obsidian logosunu ve marka varlıklarını indirin.
+
+[pages.brand.icon]
+original=Icon
+translation=Simge
+
+[pages.brand.icon_desc]
+original=For variations on the app icon, download the asset files linked\u00a0above.
+translation=For variations on the app icon, download the asset files linked\u00a0above.
+
+[pages.brand.logo_lockup]
+original=Logo lockup
+translation=Logo yerleşimi
+
+[pages.brand.logo_lockup_desc]
+original=For most applications, the lockup should be displayed as follows, using the purple mark and black or white text. For single color applications, the entire logomark should be either black or white.
+translation=Çoğu uygulama için yerleşim, mor işaret ve siyah veya beyaz metin kullanılarak aşağıdaki gibi gösterilmelidir. Tek renkli uygulamalar için tüm logo işareti siyah veya beyaz olmalıdır.
+
+[pages.brand.meta_desc]
+original=Download the Obsidian logo and brand assets.
+translation=Obsidian logosunu ve marka varlıklarını indirin.
+
+[pages.brand.meta_title]
+original=Obsidian Brand Guidelines
+translation=Obsidian Marka Yönergeleri
+
+[pages.brand.no_edit_desc]
+original=Please do not edit, change, distort, recolor, or reconfigure the Obsidian\u00a0logo.
+translation=Lütfen Obsidian logosunu düzenlemeyin, değiştirmeyin, bozmayın, yeniden renklendirmeyin veya yeniden yapılandırmayın.
+
+[pages.brand.view_on_figma_btn]
+original=View on Figma
+translation=Figma'da Görüntüle
+
+[pages.canvas.community_demos]
+original=Community demos
+translation=Topluluk demoları
+
+[pages.canvas.community_demos_desc]
+original=Explore how members of the Obsidian community are using Canvas for the personal life and at\u00a0work.
+translation=Obsidian topluluğu üyelerinin kişisel yaşamlarında ve işlerinde Tuval'i nasıl kullandıklarını keşfedin.
+
+[pages.canvas.extensible]
+original=Extensible and interoperable
+translation=Genişletilebilir ve birlikte çalışabilir
+
+[pages.canvas.extensible_1_desc]
+original=Like everything else in Obsidian, Canvas is extensible and designed to be durable. Our API makes it easy to create plugins that add new capabilities to\u00a0Canvas.
+translation=Obsidian'daki diğer her şey gibi, Tuval de genişletilebilir ve kalıcı olacak şekilde tasarlanmıştır. API'miz, Tuval'e yeni yetenekler ekleyen eklentiler oluşturmayı kolaylaştırır.
+
+[pages.canvas.extensible_2_desc]
+original=Your Canvas files are stored locally using the open {{link}} that we designed to work with other tools. Apps, scripts, and plugins can easily enhance Canvas by adding or modifying cards and\u00a0connections.
+translation=Tuval dosyalarınız, diğer araçlarla çalışacak şekilde tasarladığımız açık {{link}} kullanılarak yerel olarak saklanır. Uygulamalar, betikler ve eklentiler, kartlar ve bağlantılar ekleyerek veya düzenleyerek Tuval'i kolayca geliştirebilir.
+
+[pages.canvas.extensible_2_desc_link]
+original=JSON\u00a0Canvas file format
+translation=JSON Canvas dosya biçimi
+
+[pages.canvas.flexible]
+original=Flexible and intuitive
+translation=Esnek ve sezgisel
+
+[pages.canvas.flexible_desc]
+original=Canvas is packed with functionality. This collection of tips will help you discover how you can use Canvas to its fullest.
+translation=Tuval özelliklerle doludur. Bu ipuçları koleksiyonu, Tuval'i sonuna kadar nasıl kullanabileceğinizi keşfetmenize yardımcı olacaktır.
+
+[pages.canvas.hero]
+original=Visualize your ideas.
+translation=Fikirlerinizi görselleştirin.
+
+[pages.canvas.hero_desc]
+original=Infinite space to research, brainstorm, diagram, and lay out your ideas. Canvas comes free with\u00a0Obsidian.
+translation=Fikirlerinizi araştırmak, beyin fırtınası yapmak, şemalamak ve düzenlemek için sınırsız bir alan. Tuval, Obsidian ile ücretsiz gelir.
+
+[pages.canvas.meta_desc]
+original=Obsidian Canvas gives you infinite space to research, brainstorm, diagram, and lay out your ideas.
+translation=Obsidian Tuval; fikirlerinizi araştırmak, beyin fırtınası yapmak, şemalamak ve düzenlemek için size sınırsız bir alan sunar.
+
+[pages.canvas.meta_title]
+original=Obsidian Canvas - Visualize your ideas
+translation=Obsidian Tuval - Fikirlerinizi görselleştirin
+
+[pages.canvas.new_way]
+original=A new way to think
+translation=Düşünmenin yeni bir yolu
+
+[pages.canvas.new_way_1_desc]
+original=Effortlessly add existing notes and media from your vault, and edit them within a Canvas\u00a0view.
+translation=Kasanızdaki mevcut notları ve medyaları zahmetsizce ekleyin ve bunları bir Tuval görünümünde düzenleyin.
+
+[pages.canvas.new_way_2_desc]
+original=Canvas views can be embedded in notes, and even nested within another\u00a0Canvas.
+translation=Tuval görünümleri notların içine gömülebilir, hatta başka bir Tuval'in içine yerleştirilebilir.
+
+[pages.canvas.playground]
+original=A playground for thought
+translation=Düşünce için oyun alanı
+
+[pages.canvas.playground_1_desc]
+original=Canvas allows you to organize notes visually — an infinite space to research, brainstorm, diagram and lay out your\u00a0ideas.
+translation=Tuval, notları görsel olarak düzenlemenizi sağlar — araştırmak, beyin fırtınası yapmak, şemalamak ve fikirlerinizi düzenlemek için sınırsız bir alan.
+
+[pages.canvas.playground_2_desc]
+original=Embed your notes alongside images, PDFs, videos, audio, and even fully interactive web\u00a0pages.
+translation=Notlarınızı görseller, PDF'ler, videolar, sesler ve hatta tamamen etkileşimli web sayfalarıyla yan yana yerleştirin.
+
+[pages.changelog.subtitle_desc]
+original=Follow Obsidian updates and improvements.
+translation=Obsidian güncellemelerini ve iyileştirmelerini takip edin.
+
+[pages.cli.automate]
+original=Automate
+translation=Otomatikleştirin
+
+[pages.cli.automate_desc]
+original=Orchestrate your workflow with cron jobs, shell scripts, and custom integrations. If you can script it, you can do it.
+translation=İş akışınızı cron işleri, kabuk betikleri ve özel entegrasyonlarla düzenleyin. Betik yazabiliyorsanız yapabilirsiniz.
+
+[pages.cli.automation]
+original=Automation
+translation=Otomasyon
+
+[pages.cli.basics]
+original=Basics
+translation=Temeller
+
+[pages.cli.collaborate]
+original=Collaborate
+translation=İş birliği yapın
+
+[pages.cli.collaborate_desc]
+original=Deploy documentation, sync shared vaults to servers, and integrate Obsidian into your team’s toolchain.
+translation=Dokümantasyon dağıtın, paylaşılan kasaları sunuculara senkronize edin ve Obsidian'ı ekibinizin araç zincirine entegre edin.
+
+[pages.cli.develop]
+original=Develop
+translation=Geliştirin
+
+[pages.cli.develop_desc]
+original=Build plugins and themes faster. Edit code, reload, test, and debug without leaving the terminal.
+translation=Eklentileri ve temaları daha hızlı oluşturun. Terminalden ayrılmadan kod düzenleyin, yeniden yükleyin, test edin ve hata ayıklayın.
+
+[pages.cli.examples_desc]
+original=Check out practical examples, from everyday note-taking to developer automation.
+translation=Günlük not almadan geliştirici otomasyonuna kadar pratik örneklere göz atın.
+
+[pages.cli.first_command]
+original=Run your first command
+translation=İlk komutunuzu çalıştırın
+
+[pages.cli.first_command_desc]
+original=Once installed, you’re ready to go. Note that the Obsidian app must be running.
+translation=Once installed, you’re ready to go. Note that the Obsidian app must be running.
+
+[pages.cli.get_started_desc]
+original=Learn how to install and use Obsidian CLI.
+translation=Obsidian CLI'yı nasıl kuracağınızı ve kullanacağınızı öğrenin.
+
+[pages.cli.headless_agents]
+original=Give agentic tools access to a vault without access to your full computer.
+translation=Yapay zeka etmen araçlarına, bilgisayarınızın tamamına erişim vermeden sadece bir kasaya erişim sağlayın.
+
+[pages.cli.headless_automations]
+original=Run scheduled automations — aggregate daily notes into weekly summaries, auto-tag, and more.
+translation=Planlanmış otomasyonları çalıştırın — günlük notları haftalık özetlerde birleştirin, otomatik etiketleyin ve daha fazlasını yapın.
+
+[pages.cli.headless_backup]
+original=Automate remote backups.
+translation=Uzak yedeklemeleri otomatikleştirin.
+
+[pages.cli.headless_desc]
+original=Run {{link}} without a GUI. All the speed, privacy, and end-to-end encryption of Obsidian Sync, on any server or automated environment.
+translation=Run {{link}} without a GUI. All the speed, privacy, and end-to-end encryption of Obsidian Sync, on any server or automated environment.
+
+[pages.cli.headless_publish]
+original=Automate publishing a website.
+translation=Bir web sitesi yayınlamayı otomatikleştirin.
+
+[pages.cli.headless_team]
+original=Sync a shared team vault to a server that feeds other tools.
+translation=Sync a shared team vault to a server that feeds other tools.
+
+[pages.cli.hero]
+original=Command your vault.
+translation=Kasanıza hükmedin.
+
+[pages.cli.hero_desc]
+original=Anything you can do in Obsidian you can do from the command line.
+translation=Anything you can do in Obsidian you can do from the command line.
+
+[pages.cli.install]
+original=Install Obsidian CLI
+translation=Obsidian CLI Kurun
+
+[pages.cli.install_linux_desc]
+original=The CLI binary is copied to `~/.local/bin/obsidian`. Make sure `~/.local/bin` is in your\u00a0PATH.
+translation=CLI ikili dosyası `~/.local/bin/obsidian` konumuna kopyalanır. `~/.local/bin` klasörünün PATH değişkeninizde olduğundan emin olun.
+
+[pages.cli.install_macos_desc]
+original=Registration creates a symlink at `/usr/local/bin/obsidian`. This requires administrator privileges. You will be prompted via a system\u00a0dialog.
+translation=Registration creates a symlink at `/usr/local/bin/obsidian`. This requires administrator privileges. You will be prompted via a system\u00a0dialog.
+
+[pages.cli.install_step1]
+original=Update Obsidian
+translation=Obsidian'ı Güncelleyin
+
+[pages.cli.install_step1_desc]
+original=Download the latest Obsidian installer.
+translation=Download the latest Obsidian installer.
+
+[pages.cli.install_step2]
+original=Activate the CLI
+translation=CLI'yı Etkinleştirin
+
+[pages.cli.install_step2_desc]
+original=Enable **Command line interface** in **Settings** → **General**.
+translation=Enable **Command line interface** in **Settings** → **General**.
+
+[pages.cli.install_step3]
+original=Register the CLI
+translation=CLI'yı Kaydedin
+
+[pages.cli.install_step3_desc]
+original=Follow the on-screen instructions to add the CLI to your system PATH. Restart your terminal for changes to take\u00a0effect.
+translation=Follow the on-screen instructions to add the CLI to your system PATH. Restart your terminal for changes to take\u00a0effect.
+
+[pages.cli.install_windows_desc]
+original=The installer adds an `Obsidian.com` terminal redirector alongside `Obsidian.exe`. This is required because Obsidian runs as a GUI app.
+translation=The installer adds an `Obsidian.com` terminal redirector alongside `Obsidian.exe`. This is required because Obsidian runs as a GUI app.
+
+[pages.cli.mock_ex_append]
+original=Add a task to your daily note
+translation=Günlük notunuza bir görev ekleyin
+
+[pages.cli.mock_ex_auto_export]
+original=Search a specific vault and export as JSON
+translation=Search a specific vault and export as JSON
+
+[pages.cli.mock_ex_auto_recent]
+original=Copy recent files to clipboard
+translation=Copy recent files to clipboard
+
+[pages.cli.mock_ex_auto_tasks]
+original=Add routine tasks
+translation=Add routine tasks
+
+[pages.cli.mock_ex_auto_title]
+original=Morning routine automation
+translation=Morning routine automation
+
+[pages.cli.mock_ex_auto_unresolved]
+original=Check for unresolved links
+translation=Check for unresolved links
+
+[pages.cli.mock_ex_create]
+original=Create a new note from template
+translation=Create a new note from template
+
+[pages.cli.mock_ex_css]
+original=Inspect CSS properties
+translation=Inspect CSS properties
+
+[pages.cli.mock_ex_daily]
+original=Open today's daily note
+translation=Bugünün günlük notunu açın
+
+[pages.cli.mock_ex_devtools]
+original=Open DevTools
+translation=Open DevTools
+
+[pages.cli.mock_ex_diff]
+original=Compare two versions of a file
+translation=Compare two versions of a file
+
+[pages.cli.mock_ex_dom]
+original=Query DOM elements
+translation=Query DOM elements
+
+[pages.cli.mock_ex_errors]
+original=Review JS errors
+translation=Review JS errors
+
+[pages.cli.mock_ex_eval]
+original=Execute JavaScript
+translation=Execute JavaScript
+
+[pages.cli.mock_ex_help]
+original=Show help
+translation=Show help
+
+[pages.cli.mock_ex_read]
+original=Read current file
+translation=Read current file
+
+[pages.cli.mock_ex_reload]
+original=Reload plugin in development
+translation=Geliştirme aşamasındaki eklentiyi yeniden yükleyin
+
+[pages.cli.mock_ex_screenshot]
+original=Capture app screenshot
+translation=Capture app screenshot
+
+[pages.cli.mock_ex_search]
+original=Search your vault
+translation=Kasanızda arama yapın
+
+[pages.cli.mock_ex_tags]
+original=View all tags with frequency
+translation=View all tags with frequency
+
+[pages.cli.mock_ex_tasks]
+original=List all tasks from daily note
+translation=List all tasks from daily note
+
+[pages.cli.mock_ex_tui]
+original=Open TUI (with autocomplete)
+translation=Open TUI (with autocomplete)
+
+[pages.cli.mock_terminal]
+original=terminal
+translation=terminal
+
+[pages.cli.mock_val_01]
+original=Buy groceries
+translation=Market alışverişi yap
+
+[pages.cli.mock_val_02]
+original=Check calendar
+translation=Takvimi kontrol et
+
+[pages.cli.mock_val_03]
+original=meeting notes
+translation=toplantı notları
+
+[pages.cli.mock_val_04]
+original=Review inbox
+translation=Gelen kutusunu incele
+
+[pages.cli.mock_val_05]
+original=Travel
+translation=Seyahat
+
+[pages.cli.mock_val_06]
+original=Trip to Paris
+translation=Paris seyahati
+
+[pages.cli.sc_accept_first]
+original=Accept first suggestion
+translation=İlk öneriyi kabul et
+
+[pages.cli.sc_accept_proposal]
+original=Accept suggestion
+translation=Öneriyi kabul et
+
+[pages.cli.sc_cancel]
+original=Cancel
+translation=İptal
+
+[pages.cli.sc_clear]
+original=Clear screen
+translation=Ekranı temizle
+
+[pages.cli.sc_cursor_left]
+original=Move left
+translation=Sola taşı
+
+[pages.cli.sc_cursor_right]
+original=Move right
+translation=Sağa taşı
+
+[pages.cli.sc_delete_line_end]
+original=Delete to end of line
+translation=Satırın sonuna kadar sil
+
+[pages.cli.sc_delete_line_start]
+original=Delete to start of line
+translation=Satırın başına kadar sil
+
+[pages.cli.sc_delete_word]
+original=Delete previous word
+translation=Önceki kelimeyi sil
+
+[pages.cli.sc_editing]
+original=Editing
+translation=Düzenleme
+
+[pages.cli.sc_exit]
+original=Exit
+translation=Çıkış
+
+[pages.cli.sc_exit_suggestion]
+original=Dismiss suggestions
+translation=Önerileri kapat
+
+[pages.cli.sc_general]
+original=General
+translation=Genel
+
+[pages.cli.sc_line_end]
+original=End of line
+translation=Satır sonu
+
+[pages.cli.sc_line_start]
+original=Start of line
+translation=Satır başı
+
+[pages.cli.sc_nav]
+original=Navigation
+translation=Gezinme
+
+[pages.cli.sc_next_history]
+original=Next command
+translation=Sonraki komut
+
+[pages.cli.sc_prev_history]
+original=Previous command
+translation=Önceki komut
+
+[pages.cli.sc_reverse_search]
+original=Search history
+translation=Arama geçmişi
+
+[pages.cli.sc_word_back]
+original=Previous word
+translation=Önceki kelime
+
+[pages.cli.sc_word_forward]
+original=Next word
+translation=Sonraki kelime
+
+[pages.cli.shortcuts]
+original=Keyboard shortcuts
+translation=Klavye kısayolları
+
+[pages.cli.shortcuts_desc]
+original=Convenient shortcuts and autocomplete built into the TUI.
+translation=TUI'ye entegre edilmiş kullanışlı kısayollar ve otomatik tamamlama.
+
+[pages.cli.single_command]
+original=Run a command
+translation=Bir komut çalıştırın
+
+[pages.cli.tagline]
+original=Obsidian CLI is a programmatic playground for plain text.
+translation=Obsidian CLI, düz metin için programlanabilir bir oyun alanıdır.
+
+[pages.cli.tinker]
+original=Tinker
+translation=Kurcalayın
+
+[pages.cli.tinker_desc]
+original=Read, search, and write to your vault programmatically. Give agentic tools the ability to interact with your vault.
+translation=Kasanızı programlı olarak okuyun, arayın ve yazın. Yapay zeka etmen araçlarına kasanızla etkileşime girme yeteneği verin.
+
+[pages.cli.tui_mode]
+original=Use TUI mode
+translation=TUI modunu kullanın
+
+[pages.cli.use_it]
+original=See it in action
+translation=Çalışırken görün
+
+[pages.clipper.academic]
+original=Academic papers
+translation=Akademik makaleler
+
+[pages.clipper.academic_desc]
+original=including code and\u00a0math.
+translation=kod ve\u00a0matematik dahil.
+
+[pages.clipper.add_to_btn]
+original=Add to 
+translation=Şuna ekle: 
+
+[pages.clipper.articles]
+original=Articles
+translation=Makaleler
+
+[pages.clipper.articles_desc]
+original=including citations and\u00a0footnotes.
+translation=atıflar ve\u00a0dipnotlar dahil.
+
+[pages.clipper.auto_templates]
+original=Auto-apply templates
+translation=Şablonları otomatik uygula
+
+[pages.clipper.auto_templates_desc]
+original=Set up rules to automatically apply the right template based on the website you’re clipping\u00a0from.
+translation=Kırptığınız web sitesine göre doğru şablonu otomatik olarak uygulayacak kurallar belirleyin.
+
+[pages.clipper.capture]
+original=Capture
+translation=Yakala
+
+[pages.clipper.capture_desc]
+original=Templates allow you to customize how web pages are saved to your\u00a0vault.
+translation=Şablonlar, web sayfalarının kasanıza nasıl kaydedileceğini özelleştirmenize olanak tanır.
+
+[pages.clipper.capture_title]
+original=Easily capture pages and metadata to durable files you can read\u00a0offline.
+translation=Web sayfalarını ve meta verileri çevrimdışı okuyabileceğiniz kalıcı dosyalara kolayca kaydedin.
+
+[pages.clipper.clip]
+original=Clip
+translation=Kırpın
+
+[pages.clipper.clip_desc]
+original=your highlights to Obsidian in one\u00a0click.
+translation=vurgularınızı tek bir\u00a0tıkla Obsidian'a kırpın.
+
+[pages.clipper.custom_templates]
+original=Custom templates
+translation=Özel şablonlar
+
+[pages.clipper.custom_templates_desc]
+original=for your favorite\u00a0sites.
+translation=favori siteleriniz\u00a0için.
+
+[pages.clipper.extract]
+original=Extract anything
+translation=Her şeyi çıkarın
+
+[pages.clipper.extract_desc]
+original=Capture any data from the page: meta tags, Schema.org variables, and even element\u00a0selectors.
+translation=Capture any data from the page: meta tags, Schema.org variables, and even element\u00a0selectors.
+
+[pages.clipper.features_desc]
+original=Web Clipper is free, {{link}}, and packed with useful features that make your favorite browser a sharper\u00a0tool.
+translation=Web Clipper is free, {{link}}, and packed with useful features that make your favorite browser a sharper\u00a0tool.
+
+[pages.clipper.features_desc_link]
+original=open source
+translation=açık kaynaklıdır
+
+[pages.clipper.features_heading]
+original=Bring the web to your personal knowledge base.
+translation=Web'i kişisel bilgi tabanınıza taşıyın.
+
+[pages.clipper.hero]
+original=Save\u00a0the\u00a0web.
+translation=Web'i\u00a0kaydedin.
+
+[pages.clipper.hero_desc]
+original=Highlight and capture web pages in your favorite\u00a0browser. Save anything and everything with just one\u00a0click.
+translation=Favori tarayıcınızda web sayfalarını vurgulayın ve kırpın. Sadece tek bir tıkla her şeyi kaydedin.
+
+[pages.clipper.highlight]
+original=Highlight
+translation=Vurgula
+
+[pages.clipper.highlight_desc]
+original=Easily highlight important passages you want to save to Obsidian. Your highlights are always visible, so you can revisit them when you return to a\u00a0page.
+translation=Easily highlight important passages you want to save to Obsidian. Your highlights are always visible, so you can revisit them when you return to a\u00a0page.
+
+[pages.clipper.highlight_text]
+original=Highlight
+translation=Vurgulayın
+
+[pages.clipper.highlight_text_desc]
+original=text, images, and blocks of\u00a0content.
+translation=metin, görsel ve içerik\u00a0bloklarını.
+
+[pages.clipper.highlight_title]
+original=Highlight the web.
+translation=Web'i vurgulayın.
+
+[pages.clipper.hotkeys_desc]
+original=Speed up your workflow with keyboard shortcuts to quickly add content to your\u00a0vault.
+translation=Kasanıza hızlıca içerik eklemek için klavye kısayolları ile iş akışınızı hızlandırın.
+
+[pages.clipper.manipulate]
+original=Manipulate page data
+translation=Sayfa verilerini işleyin
+
+[pages.clipper.manipulate_desc]
+original=Powerful {{link}} allow you to modify page data before it’s saved to your\u00a0vault.
+translation=Powerful {{link}} allow you to modify page data before it’s saved to your\u00a0vault.
+
+[pages.clipper.manipulate_desc_link]
+original=templating features
+translation=şablon oluşturma özellikleri
+
+[pages.clipper.meta_desc]
+original=Highlight and capture web pages in your favorite browser. Save anything and everything with just one click.
+translation=Favori tarayıcınızda web sayfalarını vurgulayın ve kırpın. Sadece tek bir tıkla her şeyi kaydedin.
+
+[pages.clipper.more_browsers]
+original=More\u00a0browsers
+translation=Daha\u00a0fazla\u00a0tarayıcı
+
+[pages.clipper.no_lockin]
+original=No lock-in
+translation=Kilitlenme yok
+
+[pages.clipper.no_lockin_desc]
+original=Your clips are saved to durable Markdown files. All your highlights and settings are exportable to\u00a0JSON.
+translation=Your clips are saved to durable Markdown files. All your highlights and settings are exportable to\u00a0JSON.
+
+[pages.clipper.private]
+original=Stay private
+translation=Gizli kalın
+
+[pages.clipper.private_desc]
+original=All your clipped content is stored locally in your Obsidian vault. Your thoughts are yours.
+translation=All your clipped content is stored locally in your Obsidian vault. Your thoughts are yours.
+
+[pages.clipper.recipes]
+original=Recipes
+translation=Tarifler
+
+[pages.clipper.recipes_desc]
+original=with ingredients, steps, and\u00a0nutrition.
+translation=malzemeler, adımlar ve\u00a0besin değerleriyle.
+
+[pages.clipper.references]
+original=References
+translation=Referanslar
+
+[pages.clipper.references_desc]
+original=for books, movies, or\u00a0podcasts.
+translation=kitaplar, filmler veya\u00a0podcast'ler için.
+
+[pages.community.developers_btn]
+original=Explore docs
+translation=Dokümanları inceleyin
+
+[pages.community.developers_desc]
+original=Learn how to build your own Obsidian plugins and themes using our open API and documentation.
+translation=Learn how to build your own Obsidian plugins and themes using our open API and documentation.
+
+[pages.community.discord_btn]
+original=Join the conversation
+translation=Sohbete katılın
+
+[pages.community.discord_desc]
+original=Get help, ask questions, and get to know other Obsidian users and their setup!
+translation=Get help, ask questions, and get to know other Obsidian users and their setup!
+
+[pages.community.forum_btn]
+original=Visit the forum
+translation=Forumu ziyaret edin
+
+[pages.community.forum_desc]
+original=Post feature requests, report bugs, and have in-depth discussions about knowledge management.
+translation=Post feature requests, report bugs, and have in-depth discussions about knowledge management.
+
+[pages.community.hero]
+original=Join the community
+translation=Topluluğa katılın
+
+[pages.community.merch]
+original=Merch
+translation=Ürünler
+
+[pages.community.merch_btn]
+original=Visit the store
+translation=Mağazayı ziyaret edin
+
+[pages.community.merch_desc]
+original=Official Obsidian apparel and accessories for analog connections. Worldwide\u00a0shipping.
+translation=Official Obsidian apparel and accessories for analog connections. Worldwide\u00a0shipping.
+
+[pages.community.meta_desc]
+original=Join the community where you can meet Obsidian users, ask questions, report bugs, post feature requests, and more.
+translation=Obsidian kullanıcılarıyla tanışabileceğiniz, sorular sorabileceğiniz, hata bildiriminde bulunabileceğiniz, özellik talepleri gönderebileceğiniz topluluğumuza katılın.
+
+[pages.download.app]
+original=App
+translation=Uygulama
+
+[pages.download.community_maintained]
+original=Community\u00a0maintained
+translation=Topluluk\u00a0tarafından\u00a0yönetilen
+
+[pages.download.download_for_btn]
+original=Download for 
+translation=Şunun için indir: 
+
+[pages.download.meta_desc]
+original=Obsidian is available on all major platforms. Download Obsidian for iOS, Android, macOS, Windows and Linux.
+translation=Obsidian is available on all major platforms. Download Obsidian for iOS, Android, macOS, Windows and Linux.
+
+[pages.download.universal]
+original=Universal
+translation=Evrensel
+
+[pages.enterprise.add_support_btn]
+original=Add  your support
+translation=Desteğinizi ekleyin
+
+[pages.enterprise.buy_license_btn]
+original=Buy a license
+translation=Bir lisans satın al
+
+[pages.enterprise.filter_all]
+original=All
+translation=Hepsi
+
+[pages.enterprise.filter_cloud]
+original=Cloud
+translation=Bulut
+
+[pages.enterprise.filter_consumer]
+original=Consumer
+translation=Tüketici
+
+[pages.enterprise.filter_entertainment]
+original=Entertainment
+translation=Eğlence
+
+[pages.enterprise.filter_finance]
+original=Finance
+translation=Finans
+
+[pages.enterprise.filter_government]
+original=Government
+translation=Kamu
+
+[pages.enterprise.filter_health]
+original=Health
+translation=Sağlık
+
+[pages.enterprise.filter_industrial]
+original=Industrial
+translation=Endüstriyel
+
+[pages.enterprise.filter_security]
+original=Security
+translation=Güvenlik
+
+[pages.enterprise.hero]
+original=Meet the teams that trust Obsidian.
+translation=Obsidian'a güvenen ekiplerle tanışın.
+
+[pages.enterprise.hero_desc]
+original=Organizations that demand the {{link}} trust Obsidian. Their teams rely on Obsidian to think more effectively and keep total ownership over private\u00a0data.
+translation=Organizations that demand the {{link}} trust Obsidian. Their teams rely on Obsidian to think more effectively and keep total ownership over private\u00a0data.
+
+[pages.enterprise.hero_desc_link]
+original=highest security
+translation=En yüksek güvenliği
+
+[pages.enterprise.meta_desc]
+original=Organizations that demand the highest security trust Obsidian. Their teams rely on Obsidian to think more effectively and keep total ownership over private data.
+translation=En yüksek güvenliği talep eden kuruluşlar Obsidian'a güveniyor. Ekipleri daha etkili düşünmek ve özel verilerin tüm mülkiyetini korumak için Obsidian'a güveniyor.
+
+[pages.enterprise.meta_title]
+original=Meet the teams that trust Obsidian
+translation=Obsidian'a güvenen ekiplerle tanışın
+
+[pages.enterprise.show_support]
+original=Show your support
+translation=Desteğinizi gösterin
+
+[pages.enterprise.show_support_desc]
+original=Obsidian is 100% user-supported. Join the movement. Support independent software.
+translation=Obsidian is 100% user-supported. Join the movement. Support independent software.
+
+[pages.enterprise.supporters_suffix]
+original=supporters
+translation=destekçi
+
+[pages.enterprise.supporting_orgs]
+original=Supporting organizations
+translation=Destekleyen kuruluşlar
+
+[pages.enterprise.supporting_orgs_desc]
+original=More than 10,000 organizations help keep Obsidian 100% user-supported. Join them with the purchase of a commercial license.
+translation=More than 10,000 organizations help keep Obsidian 100% user-supported. Join them with the purchase of a commercial license.
+
+[pages.index.canvas_desc]
+original=An infinite space to research, brainstorm, diagram, and lay out your ideas. Canvas is a limitless playground for your mind. {{link}}
+translation=Fikirlerinizi araştırmak, beyin fırtınası yapmak, şemalamak ve düzenlemek için sınırsız bir alan. Tuval zihniniz için sınırsız bir oyun alanıdır. {{link}}
+
+[pages.index.collaboration_desc]
+original=Work with your team on shared files without compromising your private\u00a0data.
+translation=Özel verilerinizden ödün vermeden paylaşılan dosyalar üzerinde ekibinizle birlikte çalışın.
+
+[pages.index.customization]
+original=Customization
+translation=Özelleştirme
+
+[pages.index.customization_desc]
+original=Control the look and feel of your site with themes, custom domains, password protection, and\u00a0more.
+translation=Control the look and feel of your site with themes, custom domains, password protection, and\u00a0more.
+
+[pages.index.developer_docs]
+original=Developer docs
+translation=Geliştirici dokümanları
+
+[pages.index.developer_docs_desc]
+original=Learn how to build your own Obsidian plugins and themes, using our open API and documentation.
+translation=Learn how to build your own Obsidian plugins and themes, using our open API and documentation.
+
+[pages.index.discussion_forum]
+original=Discussion forum
+translation=Tartışma forumu
+
+[pages.index.discussion_forum_desc]
+original=Post feature requests, report bugs, and explore in-depth discussions about knowledge management.
+translation=Post feature requests, report bugs, and explore in-depth discussions about knowledge management.
+
+[pages.index.download_now_btn]
+original=Download now
+translation=Şimdi indir
+
+[pages.index.explore_help_desc]
+original=Explore the {{link1}} site, powered\u00a0by\u00a0{{link2}}.
+translation={{link2}} tarafından desteklenen {{link1}} sitesini keşfedin.
+
+[pages.index.explore_help_desc_link1]
+original=Obsidian Help
+translation=Obsidian Yardım
+
+[pages.index.explore_help_desc_link2]
+original=Obsidian\u00a0Publish
+translation=Obsidian\u00a0Publish
+
+[pages.index.fine_grained_control]
+original=Fine-grained control
+translation=Ayrıntılı kontrol
+
+[pages.index.fine_grained_control_desc]
+original=Decide which files and preferences you want to sync to which\u00a0devices.
+translation=Decide which files and preferences you want to sync to which\u00a0devices.
+
+[pages.index.free_without_limits]
+original=Free without limits.
+translation=Sınırsız ve ücretsiz.
+
+[pages.index.get_obsidian_btn]
+original=Get Obsidian
+translation=Obsidian Edinin
+
+[pages.index.get_obsidian_for_btn]
+original=Get Obsidian for 
+translation=Şunun için Obsidian edinin: 
+
+[pages.index.graph_desc]
+original=Visualize the relationships between your notes. Find hidden patterns in your thinking through a visually engaging and interactive\u00a0graph.
+translation=Notlarınız arasındaki ilişkileri görselleştirin. Görsel olarak ilgi çekici ve etkileşimli bir grafik aracılığıyla düşüncelerinizdeki gizli kalıpları bulun. {{link}}
+
+[pages.index.hero_subtitle_desc]
+original=The free and flexible app for your private\u00a0thoughts.
+translation=Kişisel düşünceleriniz için ücretsiz ve esnek uygulama.
+
+[pages.index.hero_title]
+original=Sharpen your thinking.
+translation=Düşüncelerinizi keskinleştirin.
+
+[pages.index.join_discord]
+original=Join us on Discord
+translation=Discord'da bize katılın
+
+[pages.index.join_discord_desc]
+original=Get help, ask questions, meet other Obsidian users, and learn about their\u00a0setup.
+translation=Get help, ask questions, meet other Obsidian users, and learn about their\u00a0setup.
+
+[pages.index.knowledge_desc]
+original=Obsidian uses open file formats, so you’re never locked\u00a0in. You own your data for the long\u00a0term.
+translation=Obsidian açık dosya biçimleri kullanır, böylece asla kilitlenip kalmazsınız. Uzun vadede verilerinizin sahibi siz olursunuz.
+
+[pages.index.knowledge_title]
+original=Your knowledge should last.
+translation=Bilginiz kalıcı olmalıdır.
+
+[pages.index.links_desc]
+original=Create connections between your notes. Link anything and everything — ideas, people, places, books, and beyond. Invent your own personal Wikipedia.
+translation=Create connections between your notes. Link anything and everything — ideas, people, places, books, and beyond. Invent your own personal Wikipedia.
+
+[pages.index.meta_desc]
+original=The free and flexible app for your private thoughts.
+translation=Kişisel düşünceleriniz için ücretsiz ve esnek uygulama.
+
+[pages.index.meta_title]
+original=Obsidian - Sharpen your thinking
+translation=Obsidian - Düşüncelerinizi keskinleştirin
+
+[pages.index.mind_desc]
+original=With {{link}} and themes, you can shape Obsidian to fit your way of\u00a0thinking.
+translation=With {{link}} and themes, you can shape Obsidian to fit your way of\u00a0thinking.
+
+[pages.index.mind_desc_link]
+original=thousands of plugins
+translation=Binlerce eklenti
+
+[pages.index.mind_title]
+original=Your mind is unique.
+translation=Zihniniz benzersizdir.
+
+[pages.index.mock_canvas_cogito]
+original=Cogito, ergo sum
+translation=Cogito, ergo sum
+
+[pages.index.mock_canvas_empiricists]
+original=Empiricists
+translation=Ampiristler (Deneyciler)
+
+[pages.index.mock_canvas_empiricists_1]
+original=Experience and sensory perception → acquire knowledge
+translation=Deneyim ve duyusal algı → bilgi edinme
+
+[pages.index.mock_canvas_empiricists_2]
+original=All knowledge is derived from experience and observation of the external world
+translation=Tüm bilgiler deneyimden ve dış dünyanın gözlemlenmesinden elde edilir
+
+[pages.index.mock_canvas_empiricists_3]
+original=A posteriori reasoning
+translation=A posteriori akıl yürütme
+
+[pages.index.mock_canvas_lecture]
+original=Lecture 1
+translation=Ders 1
+
+[pages.index.mock_canvas_philosophers]
+original=Philosophers
+translation=Filozoflar
+
+[pages.index.mock_canvas_rationalists]
+original=Rationalists
+translation=Rasyonalistler (Akılcılar)
+
+[pages.index.mock_canvas_rationalists_1]
+original=Reason and innate knowledge → acquire knowledge
+translation=Akıl ve doğuştan gelen bilgi → bilgi edinme
+
+[pages.index.mock_canvas_rationalists_2]
+original=Fundamental truths and principles can be known independent of experience
+translation=Temel gerçekler ve ilkeler deneyimden bağımsız olarak bilinebilir
+
+[pages.index.mock_canvas_rationalists_3]
+original=A priori reasoning
+translation=A priori akıl yürütme
+
+[pages.index.mock_canvas_rationalists_4]
+original=Reason and deduction
+translation=Akıl ve tümdengelim
+
+[pages.index.mock_diff_added]
+original=Obsidian stores your notes locally as plain text Markdown files.
+translation=Obsidian notlarınızı yerel olarak düz metin Markdown dosyaları olarak saklar.
+
+[pages.index.mock_diff_context_1]
+original=Create links between your notes
+translation=Notlarınız arasında bağlantılar oluşturun
+
+[pages.index.mock_diff_context_2]
+original=Use tags to organize your ideas
+translation=Fikirlerinizi düzenlemek için etiketleri kullanın
+
+[pages.index.mock_diff_new_line]
+original=Build your own personal wiki
+translation=Kendi kişisel wikinizi oluşturun
+
+[pages.index.mock_diff_removed]
+original=Obsidian saves notes as text files.
+translation=Obsidian saves notes as text files.
+
+[pages.index.mock_graph_books]
+original=Books
+translation=Kitaplar
+
+[pages.index.mock_graph_descartes]
+original=René Descartes
+translation=René Descartes
+
+[pages.index.mock_graph_philosophy]
+original=Philosophy
+translation=Felsefe
+
+[pages.index.mock_hero_backlinks]
+original=1 backlink
+translation=1 geri bağlantı
+
+[pages.index.mock_hero_blockquote]
+original=Look, here’s a table covered with red cloth. On it is a cage the size of a small fish aquarium. In the cage is a white rabbit with a pink nose and pink-rimmed eyes. On its back, clearly marked in blue ink, is the numeral 8. The most interesting thing here isn’t even the carrot-munching rabbit in the cage, but the number on its back. I never opened my mouth and you never opened yours. We’re not even in the same year together, let alone the same room... except we are together. We are close. We’re having a meeting of the minds. We’ve engaged in an act of telepathy.
+translation=Bakın, işte kırmızı örtüyle kaplı bir masa. Üzerinde küçük bir balık akvaryumu büyüklüğünde bir kafes var. Kafesin içinde pembe burunlu, pembe halkalı gözleri olan beyaz bir tavşan duruyor. Sırtında, mavi mürekkeple net bir şekilde yazılmış 8 rakamı var. Buradaki en ilginç şey kafesteki havuç kemiren tavşan değil, sırtındaki sayıdır. Ben ağzımı hiç açmadım, siz de açmadınız. Bırakın aynı odayı, aynı yılda bile birlikte değiliz... yine de birlikteyiz. Yakınız. Zihinlerin buluşmasını yaşıyoruz. Bir telepati eylemi gerçekleştirdik.
+
+[pages.index.mock_hero_bullet_1]
+original=A **sending place**, a transmission place — where the writer sends ideas, such as a desk
+translation=Bir **gönderme yeri**, aktarım yeri — yazarın fikirleri gönderdiği yer, örneğin bir çalışma masası
+
+[pages.index.mock_hero_bullet_2]
+original=A **receiving place** — where the reader receives the ideas/imagery such as a couch, a comfortable chair, in bed
+translation=Bir **alma yeri** — okuyucunun fikirleri/imgeleri aldığı yer, örneğin bir kanepe, rahat bir sandalye veya yatak
+
+[pages.index.mock_hero_chars]
+original=1139 char
+translation=1139 karakter
+
+[pages.index.mock_hero_file_01]
+original=Clippings
+translation=Kırpılanlar
+
+[pages.index.mock_hero_file_02]
+original=Daily
+translation=Günlük
+
+[pages.index.mock_hero_file_03]
+original=Ideas
+translation=Fikirler
+
+[pages.index.mock_hero_file_04]
+original=Meta
+translation=Meta
+
+[pages.index.mock_hero_file_05]
+original=Projects
+translation=Projeler
+
+[pages.index.mock_hero_file_06]
+original=References
+translation=Referanslar
+
+[pages.index.mock_hero_file_07]
+original=Evergreen notes
+translation=Kalıcı notlar
+
+[pages.index.mock_hero_file_08]
+original=Calmness is a superpower
+translation=Sakinlik süper bir güçtür
+
+[pages.index.mock_hero_file_09]
+original=Travel
+translation=Seyahat
+
+[pages.index.mock_hero_file_10]
+original=Creativity is combinatory u...
+translation=Yaratıcılık birleştiricidir...
+
+[pages.index.mock_hero_file_11]
+original=Emergence
+translation=Beliriş (Emergence)
+
+[pages.index.mock_hero_file_12]
+original=Recipes
+translation=Yemek Tarifleri
+
+[pages.index.mock_hero_file_13]
+original=Books
+translation=Kitaplar
+
+[pages.index.mock_hero_file_14]
+original=Health
+translation=Sağlık
+
+[pages.index.mock_hero_file_15]
+original=What if it were easy
+translation=Ya kolaysa?
+
+[pages.index.mock_hero_file_16]
+original=Tools
+translation=Araçlar
+
+[pages.index.mock_hero_file_17]
+original=Specialization is for insects
+translation=Uzmanlaşma böcekler içindir
+
+[pages.index.mock_hero_file_18]
+original=First principles
+translation=Temel ilkeler
+
+[pages.index.mock_hero_file_19]
+original=Philosophy
+translation=Felsefe
+
+[pages.index.mock_hero_file_20]
+original=A little bit every day
+translation=Her gün birazcık
+
+[pages.index.mock_hero_file_21]
+original=1,000 true fans
+translation=1.000 gerçek hayran
+
+[pages.index.mock_hero_from]
+original=From
+translation=Kaynak
+
+[pages.index.mock_hero_graph_tab]
+original=Graph of Writing is t...
+translation=Yazmanın grafiği t...
+
+[pages.index.mock_hero_h2_ideas]
+original=Ideas can travel through time and space
+translation=Fikirler zaman ve uzayda yolculuk edebilir
+
+[pages.index.mock_hero_h2_quote]
+original=Quote
+translation=Alıntı
+
+[pages.index.mock_hero_link]
+original=On Writing
+translation=Yazma Üzerine
+
+[pages.index.mock_hero_p1]
+original=Ideas can travel through time and space without being uttered out loud. The process of telepathy requires two places:
+translation=Fikirler, yüksek sesle söylenmeden zaman ve uzayda yolculuk edebilir. Telepati süreci iki yer gerektirir:
+
+[pages.index.mock_hero_phone_tag_1]
+original=#projects
+translation=#projeler
+
+[pages.index.mock_hero_phone_tag_2]
+original=#travel
+translation=#seyahat
+
+[pages.index.mock_hero_phone_title]
+original=Japan Trip Planning
+translation=Japonya Seyahat Planı
+
+[pages.index.mock_hero_phone_todo]
+original=To-do
+translation=Yapılacaklar
+
+[pages.index.mock_hero_tab_2]
+original=Evergreen notes
+translation=Kalıcı notlar
+
+[pages.index.mock_hero_tag]
+original=#evergreen
+translation=#evergreen
+
+[pages.index.mock_hero_task_01]
+original=Schedule flights
+translation=Uçuşları planla
+
+[pages.index.mock_hero_task_02]
+original=Ask for recommendations
+translation=Öneriler iste
+
+[pages.index.mock_hero_task_03]
+original=Keiko
+translation=Keiko
+
+[pages.index.mock_hero_task_04]
+original=Andrew
+translation=Andrew
+
+[pages.index.mock_hero_task_05]
+original=Garrett
+translation=Garrett
+
+[pages.index.mock_hero_task_06_link]
+original=Kyoto
+translation=Kyoto
+
+[pages.index.mock_hero_task_06_pre]
+original=Research ryokans in
+translation=Şundaki ryokanları araştır: 
+
+[pages.index.mock_hero_task_07]
+original=Itinerary
+translation=Seyahat Programı
+
+[pages.index.mock_hero_title]
+original=Writing is telepathy
+translation=Yazmak telepatidir
+
+[pages.index.mock_hero_vault]
+original=Notes
+translation=Notlar
+
+[pages.index.mock_hero_words]
+original=206 words
+translation=206 kelime
+
+[pages.index.mock_links_autocomplete_1]
+original=I **thin**k therefore I am
+translation=Düşünüyorum o halde varım
+
+[pages.index.mock_links_autocomplete_2]
+original=Just **thin**k about it
+translation=Sadece bunu düşünün
+
+[pages.index.mock_links_autocomplete_3]
+original=**Thin**king, Fast and Slow
+translation=Hızlı ve Yavaş Düşünme
+
+[pages.index.mock_links_autocomplete_4]
+original=The **Thin**g
+translation=Şey (The Thing)
+
+[pages.index.mock_links_books]
+original=Books/
+translation=Kitaplar/
+
+[pages.index.mock_links_movies]
+original=Movies/
+translation=Filmler/
+
+[pages.index.mock_links_p1]
+original=In {{link1}} the philosopher {{link2}} describes a series of doubts about the nature of reality, arriving at the famous phrase:
+translation=Filozof {{link2}}, {{link1}} adlı eserinde gerçekliğin doğası hakkında bir dizi şüpheyi anlatıyor ve şu ünlü söze ulaşıyor:
+
+[pages.index.mock_links_p1_link1]
+original=Meditations on First Philosophy
+translation=İlk Felsefe Üzerine Meditasyonlar
+
+[pages.index.mock_links_p1_link2]
+original=René Descartes
+translation=René Descartes
+
+[pages.index.mock_links_p2]
+original=He argues that doubting requires thinking, and therefore, the act of thinking confirms his existence.
+translation=Şüphe etmenin düşünmeyi gerektirdiğini ve dolayısıyla düşünme eyleminin varlığını doğruladığını savunur.
+
+[pages.index.mock_links_typed]
+original=I thin
+translation=Düşünüyo
+
+[pages.index.mock_plugins_calendar_desc]
+original=Calendar view of your daily notes.
+translation=Günlük notlarınızın Takvim görünümü.
+
+[pages.index.mock_plugins_dataview_desc]
+original=Advanced queries for the data-obsessed.
+translation=Veri tutkunları için gelişmiş sorgular.
+
+[pages.index.mock_plugins_kanban_desc]
+original=Markdown-backed kanban boards.
+translation=Markdown tabanlı kanban panoları.
+
+[pages.index.mock_plugins_outliner_desc]
+original=Work with your lists.
+translation=Listelerinizle çalışın.
+
+[pages.index.mock_plugins_tasks_desc]
+original=Track tasks across your entire vault.
+translation=Tüm kasanızdaki görevleri takip edin.
+
+[pages.index.mock_share_can_edit]
+original=Can edit
+translation=Düzenleyebilir
+
+[pages.index.mock_share_invite]
+original=Invite by email...
+translation=E-posta ile davet et...
+
+[pages.index.mock_share_owner]
+original=Owner
+translation=Sahibi
+
+[pages.index.mock_sync_activity]
+original=Sync activity
+translation=Sync etkinliği
+
+[pages.index.mock_sync_activity_desc]
+original=View log of sync activity.
+translation=Sync etkinlik günlüğünü görüntüleyin.
+
+[pages.index.mock_sync_appearance]
+original=Appearance settings
+translation=Görünüm ayarları
+
+[pages.index.mock_sync_appearance_desc]
+original=Sync dark mode, active theme and enabled snippets.
+translation=Koyu modu, aktif temayı ve etkinleştirilmiş kod parçacıklarını senkronize edin.
+
+[pages.index.mock_sync_audio]
+original=Audio
+translation=Ses
+
+[pages.index.mock_sync_audio_desc]
+original=Sync audio files to this device
+translation=Ses dosyalarını bu cihaza senkronize et
+
+[pages.index.mock_sync_deleted]
+original=Deleted files
+translation=Silinen dosyalar
+
+[pages.index.mock_sync_deleted_desc]
+original=View and restore deleted files
+translation=Silinen dosyaları görüntüleyin ve geri yükleyin
+
+[pages.index.mock_sync_excluded]
+original=Excluded folders
+translation=Hariç tutulan klasörler
+
+[pages.index.mock_sync_excluded_desc]
+original=Prevent certain folders from being synced
+translation=Belirli klasörlerin senkronize edilmesini önleyin
+
+[pages.index.mock_sync_file_recovery]
+original=File recovery
+translation=Dosya kurtarma
+
+[pages.index.mock_sync_hotkeys]
+original=Hotkeys
+translation=Kısayollar
+
+[pages.index.mock_sync_hotkeys_desc]
+original=Sync custom hotkeys.
+translation=Özel kısayolları senkronize edin.
+
+[pages.index.mock_sync_images]
+original=Images
+translation=Görseller
+
+[pages.index.mock_sync_images_desc]
+original=Sync image files to this device
+translation=Görsel dosyalarını bu cihaza senkronize et
+
+[pages.index.mock_sync_main]
+original=Main settings
+translation=Ana ayarlar
+
+[pages.index.mock_sync_main_desc]
+original=Sync editor, file, link settings.
+translation=Editör, dosya ve bağlantı ayarlarını senkronize edin.
+
+[pages.index.mock_sync_pdf]
+original=PDFs
+translation=PDF'ler
+
+[pages.index.mock_sync_pdf_desc]
+original=Sync PDF files to this device
+translation=PDF dosyalarını bu cihaza senkronize et
+
+[pages.index.mock_sync_plugins]
+original=Plugins
+translation=Eklentiler
+
+[pages.index.mock_sync_plugins_desc]
+original=Sync which plugins are enabled.
+translation=Hangi eklentilerin etkinleştirildiğini senkronize edin.
+
+[pages.index.mock_sync_selective]
+original=Selective sync
+translation=Seçici senkronizasyon
+
+[pages.index.mock_sync_snapshots]
+original=Snapshots
+translation=Anlık Görüntüler (Snapshots)
+
+[pages.index.mock_sync_snapshots_desc]
+original=View and restore snapshots.
+translation=Anlık görüntüleri görüntüleyin ve geri yükleyin.
+
+[pages.index.mock_sync_themes]
+original=Themes and snippets
+translation=Temalar ve kod parçacıkları
+
+[pages.index.mock_sync_themes_desc]
+original=Sync themes and snippets.
+translation=Temaları ve kod parçacıklarını senkronize edin.
+
+[pages.index.mock_sync_vault_config]
+original=Vault configuration
+translation=Kasa yapılandırması
+
+[pages.index.mock_sync_video]
+original=Video
+translation=Video
+
+[pages.index.mock_sync_video_desc]
+original=Sync video files to this device
+translation=Video dosyalarını bu cihaza senkronize et
+
+[pages.index.more_platforms_btn]
+original=More\u00a0platforms
+translation=Daha\u00a0fazla\u00a0platform
+
+[pages.index.optimized_performance]
+original=Optimized for performance
+translation=Performans için optimize edildi
+
+[pages.index.optimized_performance_desc]
+original=Obsidian Publish sites are fast, mobile-friendly, and optimized for SEO, no configuration required.
+translation=Obsidian Publish siteleri hızlıdır, mobil uyumludur ve SEO için optimize edilmiştir; hiçbir yapılandırma gerektirmez.
+
+[pages.index.plugins_desc]
+original=Build your ideal thinking space. With thousands of plugins and our open API, it’s easy to tailor Obsidian to fit your personal workflow. {{link}}
+translation=İdeal düşünme alanınızı oluşturun. Binlerce eklenti ve açık API'miz sayesinde Obsidian'ı kişisel iş akışınıza göre uyarlamak çok kolaydır. {{link}}
+
+[pages.index.publish_instantly]
+original=Publish instantly.
+translation=Anında yayınlayın.
+
+[pages.index.publish_instantly_desc]
+original=Turn your notes into an online wiki, knowledge base, documentation, or digital\u00a0garden. {{link}}
+translation=Notlarınızı çevrimiçi bir wiki'ye, bilgi tabanına, dokümantasyona veya dijital bahçeye dönüştürün. {{link}}
+
+[pages.index.seamless_editing]
+original=Seamless editing
+translation=Sorunsuz düzenleme
+
+[pages.index.seamless_editing_desc]
+original=Publish your notes instantly from the Obsidian app, and make it easy for readers to explore your web of\u00a0ideas.
+translation=Notlarınızı Obsidian uygulamasından anında yayınlayın ve okuyucuların fikir ağınızı keşfetmesini kolaylaştırın.
+
+[pages.index.spark_ideas]
+original=Spark ideas.
+translation=Fikirleri ateşleyin.
+
+[pages.index.spark_ideas_desc]
+original=From personal notes to journaling, knowledge bases, and project management, Obsidian gives you the tools to come up with ideas and organize\u00a0them.
+translation=Kişisel notlardan günlük tutmaya, bilgi tabanlarına ve proje yönetimine kadar Obsidian, size fikirler üretmeniz ve bunları düzenlemeniz için gereken araçları sağlar.
+
+[pages.index.sync_securely]
+original=Sync securely.
+translation=Güvenle senkronize edin.
+
+[pages.index.sync_securely_desc]
+original=Access your notes on any device, secured with end-to-end encryption. {{link}}
+translation=Uçtan uca şifreleme ile korunan notlarınıza herhangi bir cihazdan erişin. {{link}}
+
+[pages.index.thoughts_desc]
+original=Obsidian stores notes privately on your device, so you can access them quickly, even offline. No one else can read them, not even\u00a0us.
+translation=Obsidian notlarınızı cihazınızda gizli olarak saklar, böylece onlara çevrimdışıyken bile hızlıca erişebilirsiniz. Biz dahil olmak üzere hiç kimse onları okuyamaz.
+
+[pages.index.thoughts_title]
+original=Your thoughts are yours.
+translation=Düşünceleriniz sizindir.
+
+[pages.index.time_to_shine]
+original=It’s your time to\u00a0shine.
+translation=Parlama sırası sizde.
+
+[pages.index.version_history_desc]
+original=Easily track changes between revisions, with one year of version history for every\u00a0note.
+translation=Her not için bir yıllık sürüm geçmişi ile revizyonlar arasındaki değişiklikleri kolayca takip edin.
+
+[pages.mobile.feel_at_home]
+original=Feel at home
+translation=Kendinizi evinizde hissedin
+
+[pages.mobile.feel_at_home_1_desc]
+original=Obsidian Mobile brings the power of our desktop app to your mobile\u00a0devices.
+translation=Obsidian Mobil, masaüstü uygulamamızın gücünü mobil cihazlarınıza getirir.
+
+[pages.mobile.feel_at_home_2_desc]
+original=Tabs, Command Palette, plugins, custom hotkeys — everything that makes Obsidian great is here. Stay productive without another learning\u00a0curve.
+translation=Sekmeler, Komut Paleti, eklentiler, özel kısayollar — Obsidian'ı harika yapan her şey burada. Yeni bir öğrenme süreciyle uğraşmadan üretken kalın.
+
+[pages.mobile.hero]
+original=Fast. Free. Full\u2011featured.
+translation=Hızlı. Ücretsiz. Tam\u2011özellikli.
+
+[pages.mobile.hero_desc]
+original=Obsidian Mobile is your second brain on the\u00a0go. Available for free on iOS and\u00a0Android.
+translation=Obsidian Mobil, hareket halindeyken kullanabileceğiniz ikinci beyninizdir. iOS ve Android'de ücretsiz olarak sunulmaktadır.
+
+[pages.mobile.meta_desc]
+original=Obsidian Mobile brings the power of our desktop app to your mobile devices.
+translation=Obsidian Mobil, masaüstü uygulamamızın gücünü mobil cihazlarınıza taşır.
+
+[pages.mobile.meta_title]
+original=Obsidian for iOS and Android
+translation=iOS ve Android için Obsidian
+
+[pages.mobile.small_mighty]
+original=Small yet mighty
+translation=Küçük ama güçlü
+
+[pages.mobile.small_mighty_desc]
+original=Obsidian’s best features work out of the box. Core plugins, including graph view, work the same. Even better, community plugins are just a few taps away to supercharge your\u00a0workflow.
+translation=Obsidian'ın en iyi özellikleri doğrudan çalışır. Grafik görünümü de dahil olmak üzere yerleşik eklentiler aynı şekilde çalışır. Dahası, iş akışınızı güçlendirecek topluluk eklentileri sadece birkaç dokunuş uzağınızdadır.
+
+[pages.mobile.speed]
+original=Speed of thought
+translation=Düşünce hızı
+
+[pages.mobile.speed_1_desc]
+original=Obsidian Mobile is blazing fast, so you can jot things down before you forget\u00a0them.
+translation=Obsidian Mobil son derece hızlıdır, böylece unutmadan önce şeyleri hızlıca not edebilirsiniz.
+
+[pages.mobile.speed_2_desc]
+original=With the customizable toolbar and touch-friendly gestures, zip around your second brain with\u00a0ease.
+translation=Özelleştirilebilir araç çubuğu ve dokunmatik uyumlu hareketlerle ikinci beyninizde kolaylıkla gezinin.
+
+[pages.pricing.addons_desc]
+original=Optional add-on services make it easy to sync and publish your\u00a0notes.
+translation=İsteğe bağlı ek hizmetler notlarınızı senkronize etmeyi ve yayınlamayı kolaylaştırır.
+
+[pages.pricing.badges]
+original=Community badges
+translation=Topluluk rozetleri
+
+[pages.pricing.bulk_desc]
+original=For bulk purchases and other inquiries, contact us at {{link}}
+translation=Toplu satın alımlar ve diğer sorularınız için {{link}} adresinden bizimle iletişime geçin
+
+[pages.pricing.collaborate]
+original=Collaborate on shared vaults
+translation=Paylaşılan kasalarda iş birliği yapın
+
+[pages.pricing.custom_theme]
+original=Customizable theme
+translation=Özelleştirilebilir tema
+
+[pages.pricing.early_access]
+original=Early access to beta versions
+translation=Beta sürümlerine erken erişim
+
+[pages.pricing.faq_a_catalyst]
+original=By becoming a {{link1}}, you’ll receive early access to beta versions of Obsidian, as well as special badges within the community. Catalyst plays a vital role in helping Obsidian remain 100% user-supported, free from investor influence that could compromise {{link2}}.
+translation=Bir {{link1}} olarak, Obsidian'ın beta sürümlerine erken erişim hakkı kazanmanın yanı sıra topluluk içinde özel rozetler alırsınız. Catalyst, Obsidian'ın %100 kullanıcı destekli kalmasına yardımcı olarak, değerlerimizi tehlikeye atabilecek yatırımcı etkisinden uzak durmamızı sağlamada hayati bir rol oynar. {{link2}}
+
+[pages.pricing.faq_a_catalyst_link1]
+original=Catalyst member
+translation=Catalyst üyesi
+
+[pages.pricing.faq_a_catalyst_link2]
+original=our\u00a0values
+translation=değerlerimizden
+
+[pages.pricing.faq_a_commercial]
+original=No. You are not *required* to pay for a commercial license, however if you are using Obsidian for work in an organization we encourage you to purchase a commercial license to keep Obsidian independent and 100% user-supported. {{link}}
+translation=Hayır. Ticari bir lisans için ödeme yapmanız *gerekmez*, ancak Obsidian'ı bir kuruluşta iş amacıyla kullanıyorsanız, Obsidian'ı bağımsız ve %100 kullanıcı destekli tutmak için ticari bir lisans satın almanızı teşvik ederiz. {{link}}
+
+[pages.pricing.faq_a_data_1]
+original=Obsidian is a private and secure space for your thoughts. You can use our apps without sharing any personal information, and your data is stored locally on your device, making it inaccessible to us. Additionally, our apps do not collect telemetry data, and we never sell user data.
+translation=Obsidian, düşünceleriniz için özel ve güvenli bir alandır. Uygulamalarımızı herhangi bir kişisel bilgi paylaşmadan kullanabilirsiniz ve verileriniz cihazınızda yerel olarak depolanır, bu da bizim tarafımızdan erişilemez olmasını sağlar. Ayrıca, uygulamalarımız telemetri verileri toplamaz ve kullanıcı verilerini asla satmayız.
+
+[pages.pricing.faq_a_data_2]
+original=If you choose to use {{link1}}, your data is secured with AES\u2011256 end-to-end encryption, preventing us from reading it. {{link2}}
+translation=Eğer {{link1}} kullanmayı seçerseniz, verileriniz AES\u2011256 uçtan uca şifreleme ile güvence altına alınır ve bizim tarafımızdan okunması engellenir. {{link2}}
+
+[pages.pricing.faq_a_data_2_link1]
+original=Obsidian Sync
+translation=Obsidian Sync
+
+[pages.pricing.faq_a_discount]
+original=Yes, we do! Students, faculty members, and nonprofit employees are eligible for a 40% discount on Obsidian Sync and Publish. We do not offer any other discounts or promotions. {{link}}
+translation=Evet, sunuyoruz! Öğrenciler, öğretim üyeleri ve kâr amacı gütmeyen kuruluş çalışanları Obsidian Sync ve Publish'te %40 indirimden yararlanabilirler. Başka bir indirim veya promosyon sunmuyoruz. {{link}}
+
+[pages.pricing.faq_a_gift]
+original=Yes! You can purchase Obsidian Credit for friends, family, and coworkers. This credit can be used to pay for any Obsidian license or service. To get started, {{link1}} and buy credit. You can then send it to the recipient via email or a shareable link. {{link2}}
+translation=Evet! Arkadaşlar, aile ve iş arkadaşları için Obsidian Kredisi satın alabilirsiniz. Bu kredi, herhangi bir Obsidian lisansı veya hizmeti için ödeme yapmak üzere kullanılabilir. Başlamak için {{link1}} ve kredi satın alın. Ardından krediyi e-posta veya paylaşılabilir bir bağlantı aracılığıyla alıcıya gönderebilirsiniz. {{link2}}
+
+[pages.pricing.faq_a_gift_link1]
+original=create an account
+translation=bir hesap oluşturun
+
+[pages.pricing.faq_a_refund]
+original=We offer full refunds within 7 days of purchase with no questions asked for Obsidian Sync and Publish. However, please note that Catalyst licenses, Commercial licenses, and Obsidian Credit are non-refundable. {{link}}
+translation=Obsidian Sync ve Publish için satın alma tarihinden itibaren 7 gün içinde koşulsuz tam iade sunuyoruz. Ancak lütfen Catalyst lisanslarının, Ticari lisansların ve Obsidian Kredisinin iade edilemez olduğunu unutmayın. {{link}}
+
+[pages.pricing.faq_desc]
+original=Frequently asked questions about pricing
+translation=Ücretlendirme hakkında sıkça sorulan sorular
+
+[pages.pricing.faq_q_catalyst]
+original=What benefits does the Catalyst license\u00a0grant?
+translation=What benefits does the Catalyst license\u00a0grant?
+
+[pages.pricing.faq_q_commercial]
+original=Do I have to pay for commercial\u00a0use?
+translation=Do I have to pay for commercial\u00a0use?
+
+[pages.pricing.faq_q_data]
+original=Do you store, access, or process user\u00a0data?
+translation=Do you store, access, or process user\u00a0data?
+
+[pages.pricing.faq_q_discount]
+original=Do you offer discounts for education, nonprofits, or other\u00a0groups?
+translation=Do you offer discounts for education, nonprofits, or other\u00a0groups?
+
+[pages.pricing.faq_q_gift]
+original=Can I buy Obsidian add-ons or licenses for someone\u00a0else?
+translation=Can I buy Obsidian add-ons or licenses for someone\u00a0else?
+
+[pages.pricing.faq_q_refund]
+original=What is your refund\u00a0policy?
+translation=What is your refund\u00a0policy?
+
+[pages.pricing.featured_org]
+original=Become a featured organization
+translation=Öne çıkan bir kuruluş olun
+
+[pages.pricing.graph_search]
+original=Graph and full text search
+translation=Grafik ve tam metin araması
+
+[pages.pricing.hero]
+original=Free without limits.
+translation=Sınırsız ve ücretsiz.
+
+[pages.pricing.meta_desc]
+original=Obsidian is free and 100% user-supported.
+translation=Obsidian ücretsizdir ve %100 kullanıcı desteklidir.
+
+[pages.pricing.more_questions_desc]
+original=More questions? Visit our {{link}}
+translation=Daha fazla sorunuz mu var? Şurayı ziyaret edin: {{link}}
+
+[pages.pricing.more_questions_desc_link]
+original=Help\u00a0site
+translation=Yardım sitemiz
+
+[pages.pricing.no_tech]
+original=No technical knowledge required
+translation=Teknik bilgi gerektirmez
+
+[pages.pricing.priority_support]
+original=Priority support
+translation=Öncelikli destek
+
+[pages.pricing.publish_web]
+original=Publish notes to the web
+translation=Notları web'de yayınlayın
+
+[pages.pricing.subtitle_desc_1]
+original=No sign-up required.
+translation=Kayıt gerekmez.
+
+[pages.pricing.subtitle_desc_2]
+original=No strings attached.
+translation=Koşulsuz, şartsız.
+
+[pages.pricing.support_btn]
+original=Support Obsidian
+translation=Obsidian'ı Destekleyin
+
+[pages.pricing.support_dev]
+original=Support development
+translation=Geliştirmeyi destekleyin
+
+[pages.pricing.sync_across]
+original=Sync notes across devices
+translation=Notları cihazlar arasında senkronize edin
+
+[pages.pricing.user_supported]
+original=100% user-supported.
+translation=%100 kullanıcı destekli.
+
+[pages.pricing.user_supported_desc]
+original=Optional licenses help support the independent development of Obsidian.
+translation=İsteğe bağlı lisanslar, Obsidian'ın bağımsız olarak geliştirilmesini desteklemeye yardımcı olur.
+
+[pages.pricing.vip]
+original=VIP channel
+translation=VIP kanalı
+
+[pages.publish.accessible]
+original=Accessible by default
+translation=Varsayılan olarak erişilebilir
+
+[pages.publish.accessible_desc]
+original=Out of the box, Obsidian Publish has a perfect 100% Lighthouse accessibility score. It’s our priority to make your content accessible for all\u00a0visitors.
+translation=Kullanıma hazır şekilde sunulan Obsidian Publish, mükemmel bir %100 Lighthouse erişilebilirlik puanına sahiptir. İçeriğinizi tüm ziyaretçiler için erişilebilir kılmak bizim önceliğimizdir.
+
+[pages.publish.analytics]
+original=Analytics are optional
+translation=Analizler isteğe bağlıdır
+
+[pages.publish.analytics_desc]
+original=Obsidian Publish is private by default, but it’s easy to track visits to your\u00a0site if you choose to. Embed Google Analytics or privacy-friendly tools such as Plausible and Fathom.
+translation=Obsidian Publish varsayılan olarak gizlidir, ancak isterseniz sitenize yapılan ziyaretleri takip etmek kolaydır. Google Analytics'i veya Plausible ve Fathom gibi gizlilik dostu araçları sitenize entegre edebilirsiniz.
+
+[pages.publish.authoring]
+original=Authoring
+translation=Yazarlık
+
+[pages.publish.backlinks_desc]
+original=Automatically list links to pages that reference the current page you are\u00a0on.
+translation=Bulunduğunuz sayfaya atıfta bulunan sayfaların bağlantılarını otomatik olarak listeleyin.
+
+[pages.publish.built_in_performance]
+original=Built-in performance
+translation=Yerleşik performans
+
+[pages.publish.collaborate]
+original=Collaborate seamlessly
+translation=Sorunsuz iş birliği yapın
+
+[pages.publish.collaborate_desc]
+original=Invite your team to collaboratively create and maintain your Publish\u00a0site.
+translation=Publish sitenizi ortaklaşa oluşturmak ve sürdürmek için ekibinizi davet edin.
+
+[pages.publish.create_site_btn]
+original=Create your site
+translation=Sitenizi oluşturun
+
+[pages.publish.custom_domain_desc]
+original=Point your domain name to Obsidian Publish for a more branded experience.
+translation=Daha markalı bir deneyim için alan adınızı Obsidian Publish'e yönlendirin.
+
+[pages.publish.custom_theme_domain]
+original=Customizable theme and domain
+translation=Özelleştirilebilir tema ve alan adı
+
+[pages.publish.customization]
+original=Customization
+translation=Özelleştirme
+
+[pages.publish.customization_desc]
+original=Obsidian Publish gives you control over the look and feel of your site. It’s easy to create a unique and branded\u00a0design.
+translation=Obsidian Publish, sitenizin görünümü ve hissi üzerinde kontrol sağlar. Benzersiz ve markalı bir tasarım oluşturmak kolaydır.
+
+[pages.publish.edit_markdown]
+original=Edit with Markdown
+translation=Markdown ile düzenleyin
+
+[pages.publish.edit_markdown_desc]
+original=Blazing fast text editing built on the simplicity and reliability of\u00a0Markdown.
+translation=Markdown'ın sadeliği ve güvenilirliği üzerine kurulmuş son derece hızlı metin düzenleme.
+
+[pages.publish.email_support]
+original=Priority email support
+translation=Öncelikli e-posta desteği
+
+[pages.publish.explore_sites_desc]
+original=Explore Publish sites by the Obsidian community
+translation=Obsidian topluluğunun Publish sitelerini keşfedin
+
+[pages.publish.features_desc]
+original=Obsidian Publish brings your connected notes online. Unique features help readers explore your web of\u00a0ideas.
+translation=Obsidian Publish, bağlantılı notlarınızı çevrimiçi ortama taşır. Benzersiz özellikler, okuyucuların fikir ağınızı keşfetmesine yardımcı olur.
+
+[pages.publish.graph_view_desc]
+original=Visually explore the connections between the pages on your\u00a0site.
+translation=Sitenizdeki sayfalar arasındaki bağlantıları görsel olarak keşfedin.
+
+[pages.publish.hero]
+original=Give your knowledge a home on the\u00a0web.
+translation=Bilginize web'de bir yuva verin.
+
+[pages.publish.hero_desc]
+original=The easiest way to publish your wiki, knowledge base, documentation, or digital\u00a0garden.
+translation=Wiki'nizi, bilgi tabanınızı, dokümantasyonunuzu veya dijital bahçenizi yayınlamanın en kolay yolu.
+
+[pages.publish.hosting]
+original=Hosting for your site up to 4GB
+translation=4 GB'a kadar siteniz için barındırma
+
+[pages.publish.hover_previews_desc]
+original=Display a popover preview of the linked page when you hover over it, like\u00a0Wikipedia.
+translation=İmleci üzerine getirdiğinizde, tıpkı Wikipedia'daki gibi, bağlantılı sayfanın popover önizlemesini görüntüleyin.
+
+[pages.publish.launch]
+original=Launch your site today
+translation=Sitenizi bugün yayınlayın
+
+[pages.publish.launch_desc]
+original=Create a Publish site from your notes in just a few\u00a0minutes.
+translation=Sadece birkaç dakika içinde notlarınızdan bir Publish sitesi oluşturun.
+
+[pages.publish.make_your_own]
+original=Make it your own
+translation=Kendinize özel hale getirin
+
+[pages.publish.meta_desc]
+original=Obsidian Publish is the easiest way to publish your wiki, knowledge base, documentation, or digital garden.
+translation=Obsidian Publish; wiki'nizi, bilgi tabanınızı, dokümantasyonunuzu veya dijital bahçenizi yayınlamanın en kolay yoluudur.
+
+[pages.publish.mobile_friendly]
+original=Mobile-friendly
+translation=Mobil uyumlu
+
+[pages.publish.mobile_friendly_desc]
+original=Visitors on mobile devices are treated as first-class citizens, with an experience that’s as intuitive and powerful as it is on the desktop. You can also edit and publish your site from the Obsidian mobile\u00a0app.
+translation=Mobil cihazlardaki ziyaretçilere, masaüstündeki kadar sezgisel ve güçlü bir deneyim sunulur. Ayrıca sitenizi Obsidian mobil uygulamasından da düzenleyebilir ve yayınlayabilirsiniz.
+
+[pages.publish.mock_pub_analytics]
+original=Google Analytics code
+translation=Google Analytics kodu
+
+[pages.publish.mock_pub_analytics_desc]
+original=Configure analytics for your domain.
+translation=Alan adınız için analizleri yapılandırın.
+
+[pages.publish.mock_pub_custom_url]
+original=Custom URL
+translation=Özel URL
+
+[pages.publish.mock_pub_custom_url_desc]
+original=Define your custom domain.
+translation=Özel alan adınızı tanımlayın.
+
+[pages.publish.mock_pub_enter_password]
+original=Enter password...
+translation=Şifreyi girin...
+
+[pages.publish.mock_pub_indexing]
+original=Disallow search engine indexing
+translation=Arama motoru dizine eklemesini engelle
+
+[pages.publish.mock_pub_indexing_desc]
+original=Prevent search engines from indexing your site.
+translation=Arama motorlarının sitenizi dizine eklemesini önleyin.
+
+[pages.publish.mock_pub_logo]
+original=Logo
+translation=Logo
+
+[pages.publish.mock_pub_logo_desc]
+original=Pick an image for your site.
+translation=Siteniz için bir görsel seçin.
+
+[pages.publish.mock_pub_password_protected]
+original=This site is password protected
+translation=Bu site şifre korumalıdır
+
+[pages.publish.mock_pub_redirect]
+original=Redirect to your domain
+translation=Alan adınıza yönlendirin
+
+[pages.publish.mock_pub_redirect_desc]
+original=Visitors to your site will be redirected.
+translation=Sitenizin ziyaretçileri yönlendirilecektir.
+
+[pages.publish.mock_pub_settings]
+original=Site settings
+translation=Site ayarları
+
+[pages.publish.mock_pub_site_name]
+original=Site name
+translation=Site adı
+
+[pages.publish.mock_pub_site_name_desc]
+original=Name of your site.
+translation=Sitenizin adı.
+
+[pages.publish.mock_pub_theme]
+original=Site theme
+translation=Site teması
+
+[pages.publish.nonlinear]
+original=The publishing platform for non-linear thinkers
+translation=Doğrusal olmayan düşünenler için yayınlama platformu
+
+[pages.publish.password_desc]
+original=Restrict access to your site with the ability to manage multiple passwords.
+translation=Restrict access to your site with the ability to manage multiple passwords.
+
+[pages.publish.performance]
+original=Performance
+translation=Performans
+
+[pages.publish.performance_desc]
+original=Speed and accessibility are built into every Obsidian Publish site. No configuration required.
+translation=Speed and accessibility are built into every Obsidian Publish site. No configuration required.
+
+[pages.publish.price]
+original=$8 per month
+translation=Aylık 8$
+
+[pages.publish.pricing_desc]
+original=Host your Obsidian Publish site for one all-inclusive price. If you’re not satisfied, get a refund within 7 days, no questions\u00a0asked.
+translation=Obsidian Publish sitenizi her şey dahil tek bir fiyatla barındırın. Memnun kalmazsanız, 7 gün içinde koşulsuz iade alabilirsiniz.
+
+[pages.publish.publish_natively]
+original=Publish natively
+translation=Doğal olarak yayınlayın
+
+[pages.publish.publish_natively_desc]
+original=Make your changes public in just a few taps, even from your mobile\u00a0devices.
+translation=Make your changes public in just a few taps, even from your mobile\u00a0devices.
+
+[pages.publish.seamless]
+original=A seamless publishing experience
+translation=A seamless publishing experience
+
+[pages.publish.seamless_desc]
+original=Publish is built into Obsidian so you can write, collaborate, and publish seamlessly.
+translation=Publish is built into Obsidian so you can write, collaborate, and publish seamlessly.
+
+[pages.publish.seo]
+original=First-class SEO
+translation=First-class SEO
+
+[pages.publish.seo_desc]
+original=Your Publish site is automatically optimized for search engines and social sharing cards. You can even customize metadata with descriptions, slugs, and images, on a page-by-page\u00a0level.
+translation=Your Publish site is automatically optimized for search engines and social sharing cards. You can even customize metadata with descriptions, slugs, and images, on a page-by-page\u00a0level.
+
+[pages.publish.seo_mobile]
+original=SEO and mobile performance
+translation=SEO and mobile performance
+
+[pages.publish.stacked_pages_desc]
+original=Make links open in horizontal panes that you can browse like a stack of pages on a\u00a0desk.
+translation=Make links open in horizontal panes that you can browse like a stack of pages on a\u00a0desk.
+
+[pages.publish.themes_desc]
+original=The look of your Obsidian Publish site can be fully customized with CSS and Javascript.
+translation=Obsidian Publish sitenizin görünümü CSS ve Javascript ile tamamen özelleştirilebilir.
+
+[pages.publish.whats_included]
+original=What’s included
+translation=Neler dahil
+
+[pages.roadmap.active]
+original=Active
+translation=Aktif
+
+[pages.roadmap.detail_desc]
+original=For more detail about individual releases see the {{link1}}. Have a feature request? Visit the {{link2}}.
+translation=Bireysel sürümler hakkında daha fazla ayrıntı için {{link1}} inceleyin. Bir özellik talebiniz mi var? {{link2}} ziyaret edin.
+
+[pages.roadmap.detail_desc_link1]
+original=Changelog
+translation=Değişiklik günlüğünü
+
+[pages.roadmap.detail_desc_link2]
+original=official\u00a0forum
+translation=resmi forumu
+
+[pages.roadmap.launched]
+original=Launched
+translation=Yayınlandı
+
+[pages.roadmap.planned]
+original=Planned
+translation=Planlandı
+
+[pages.roadmap.subtitle_desc]
+original=We’re chipping away at improvements to\u00a0Obsidian.
+translation=Obsidian'da sürekli iyileştirmeler yapıyoruz.
+
+[pages.security.audit_2023_desc]
+original=Penetration test and source code audit of Obsidian apps. Covers all existing client code to date. Following this test, the Cure53 team reported that all vulnerabilities have been addressed and the recommendations have been followed.
+translation=Obsidian uygulamalarının sızma testi ve kaynak kod denetimi. Bugüne kadarki tüm mevcut istemci kodlarını kapsar. Bu testin ardından Cure53 ekibi tüm güvenlik açıklarının giderildiğini ve önerilere uyulduğunu bildirmiştir.
+
+[pages.security.audit_2024_desc]
+original=Penetration test and source code audit of Obsidian apps. Covers all client code, with particular attention to hardening the **Web viewer** plugin ahead of its release. Following this test, the Cure53 team reported that all vulnerabilities have been addressed and the recommendations have been followed.
+translation=Obsidian uygulamalarının sızma testi ve kaynak kod denetimi. Tüm istemci kodlarını kapsar; özellikle yayınlanmasından önce **Web viewer** eklentisinin güçlendirilmesine dikkat edilmiştir. Bu testin ardından Cure53 ekibi tüm güvenlik açıklarının giderildiğini ve önerilere uyulduğunu bildirmiştir.
+
+[pages.security.audited_by]
+original=Audited by
+translation=Denetleyen:
+
+[pages.security.audits]
+original=Independent audits
+translation=Bağımsız denetimler
+
+[pages.security.audits_desc]
+original=Regular audits by third-party security firms ensure that Obsidian meets the highest security standards. These reports are shared for transparency, and any vulnerabilities are promptly\u00a0addressed.
+translation=Regular audits by third-party security firms ensure that Obsidian meets the highest security standards. These reports are shared for transparency, and any vulnerabilities are promptly\u00a0addressed.
+
+[pages.security.blog_posts]
+original=Blog posts
+translation=Blog gönderileri
+
+[pages.security.desktop_mobile]
+original=Desktop and mobile clients
+translation=Masaüstü ve mobil istemciler
+
+[pages.security.developer_policies]
+original=Developer\u00a0policies
+translation=Geliştirici yönergeleri
+
+[pages.security.e2e_desc]
+original=With Obsidian Sync, your data is secured using the strongest encryption standard, AES\u2011256.
+translation=With Obsidian Sync, your data is secured using the strongest encryption standard, AES\u2011256.
+
+[pages.security.hero_desc]
+original=Obsidian is designed to be a private and secure space for your thoughts. Here’s how we protect your\u00a0data.
+translation=Obsidian is designed to be a private and secure space for your thoughts. Here’s how we protect your\u00a0data.
+
+[pages.security.meta_desc]
+original=Obsidian is designed to be a private and secure space for your thoughts.
+translation=Obsidian, düşünceleriniz için özel ve güvenli bir alan olarak tasarlanmıştır.
+
+[pages.security.obsidian_manifesto]
+original=Obsidian Manifesto
+translation=Obsidian Manifestosu
+
+[pages.security.private]
+original=Private by default
+translation=Varsayılan olarak gizli
+
+[pages.security.private_desc]
+original=Your data is saved locally on your device. No account is required, no telemetry data is\u00a0collected.
+translation=Your data is saved locally on your device. No account is required, no telemetry data is\u00a0collected.
+
+[pages.security.related]
+original=Related information
+translation=İlgili bilgiler
+
+[pages.security.report_issue]
+original=Report a security issue
+translation=Bir güvenlik sorununu bildirin
+
+[pages.security.sync_audit_cure53_desc]
+original=Audit of the Obsidian Sync API, server, and cryptography. Following this test, the Cure53 team reported that all vulnerabilities have been addressed and the recommendations have been followed.
+translation=Obsidian Sync API, sunucu ve kriptografi denetimi. Bu testin ardından Cure53 ekibi tüm güvenlik açıklarının giderildiğini ve önerilere uyulduğunu bildirmiştir.
+
+[pages.security.sync_audit_tob_desc]
+original=Audit of the Obsidian Sync API, server, and cryptography. All findings were addressed via remediations and disclosures validated by the auditors.
+translation=Obsidian Sync API, sunucu ve kriptografi denetimi. Tüm bulgular, denetçiler tarafından onaylanan düzeltmeler ve açıklamalar yoluyla giderilmiştir.
+
+[pages.security.sync_security_faqs]
+original=Sync\u00a0security\u00a0FAQs
+translation=Sync güvenlik SSS
+
+[pages.security.transparency]
+original=Transparency
+translation=Şeffaflık
+
+[pages.security.transparency_desc]
+original=Obsidian is built on open formats, trusted encryption algorithms, and independently audited\u00a0code.
+translation=Obsidian açık biçimler, güvenilir şifreleme algoritmaları ve bağımsız olarak denetlenmiş kodlar üzerine kurulmuştur.
+
+[pages.sync.10_vaults]
+original=10 synced vaults
+translation=10 senkronize kasa
+
+[pages.sync.10gb]
+original=10 GB total storage
+translation=Toplam 10 GB depolama
+
+[pages.sync.12mo_history]
+original=12 month version history
+translation=12 aylık sürüm geçmişi
+
+[pages.sync.1_vault]
+original=1 synced vault
+translation=1 senkronize kasa
+
+[pages.sync.1gb]
+original=1 GB total storage
+translation=Toplam 1 GB depolama
+
+[pages.sync.1mo_history]
+original=1 month version history
+translation=1 aylık sürüm geçmişi
+
+[pages.sync.200mb]
+original=200 MB maximum file size
+translation=200 MB maksimum dosya boyutu
+
+[pages.sync.5mb]
+original=5 MB maximum file size
+translation=5 MB maksimum dosya boyutu
+
+[pages.sync.collaborate]
+original=Collaborate with your\u00a0team
+translation=Ekibinizle iş birliği yapın
+
+[pages.sync.collaborate_desc]
+original=Invite your team to a shared Obsidian vault. Notes are updated in real-time across your team’s devices without compromising the privacy of your company\u00a0data.
+translation=Ekibinizi paylaşılan bir Obsidian kasasına davet edin. Notlar, şirket verilerinizin gizliliğinden ödün vermeden ekibinizin cihazları arasında gerçek zamanlı olarak güncellenir.
+
+[pages.sync.configuration]
+original=Configuration
+translation=Yapılandırma
+
+[pages.sync.cross_platform]
+original=Cross-platform apps
+translation=Çok platformlu uygulamalar
+
+[pages.sync.cross_platform_desc]
+original=Obsidian is available on all major platforms, so you can sync notes to any device. Seamlessly work across Mac, Windows, Linux, iOS, Android, and even {{link}}
+translation=Obsidian tüm büyük platformlarda mevcuttur, böylece notları herhangi bir cihaza senkronize edebilirsiniz. Mac, Windows, Linux, iOS, Android ve hatta bir sunucuda grafik arayüzsüz (headless) olarak sorunsuz çalışın. {{link}}
+
+[pages.sync.cross_platform_desc_link]
+original=headless on a\u00a0server.
+translation=bir sunucuda grafik arayüzsüz (headless)
+
+[pages.sync.e2e_desc]
+original=Your data is automatically secured using AES\u2011256, the strongest encryption standard. With Obsidian\u00a0Sync you’re always in total control of your notes. {{link}}
+translation=Your data is automatically secured using AES\u2011256, the strongest encryption standard. With Obsidian\u00a0Sync you’re always in total control of your notes. {{link}}
+
+[pages.sync.features_desc]
+original=Obsidian Sync works in the background to keep your notes synchronized effortlessly and privately.
+translation=Obsidian Sync, notlarınızı zahmetsizce ve gizlilik içinde senkronize tutmak için arka planda çalışır.
+
+[pages.sync.file_recovery_desc]
+original=Restore deleted files, and get granular details on sync activities.
+translation=Restore deleted files, and get granular details on sync activities.
+
+[pages.sync.fine_grained]
+original=Fine-grained sync\u00a0control
+translation=Ayrıntılı senkronizasyon kontrolü
+
+[pages.sync.fine_grained_desc]
+original=Obsidian Sync lets you decide which files and preferences you want to sync to which\u00a0devices.
+translation=Obsidian Sync, hangi dosyaları ve tercihleri hangi cihazlarla senkronize etmek istediğinize karar vermenizi sağlar.
+
+[pages.sync.hero]
+original=All your notes, on\u00a0all your devices.
+translation=Tüm notlarınız, tüm cihazlarınızda.
+
+[pages.sync.hero_desc]
+original=The simple and secure way to sync your notes across any device and\u00a0OS.
+translation=The simple and secure way to sync your notes across any device and\u00a0OS.
+
+[pages.sync.meta_desc]
+original=Obsidian Sync is the simple and secure way to synchronize your Obsidian notes across any device and OS.
+translation=Obsidian Sync, Obsidian notlarınızı herhangi bir cihaz ve işletim sistemi arasında senkronize etmenin basit ve güvenli yoludur.
+
+[pages.sync.offline]
+original=Work offline, sync later
+translation=Çevrimdışı çalışın, sonra senkronize edin
+
+[pages.sync.offline_desc]
+original=Obsidian is designed to work even without an internet connection. When you’re flying or in a remote location, you still have access to your files. When you’re back online Sync merges changes for\u00a0you.
+translation=Obsidian is designed to work even without an internet connection. When you’re flying or in a remote location, you still have access to your files. When you’re back online Sync merges changes for\u00a0you.
+
+[pages.sync.plus]
+original=Sync\u00a0Plus
+translation=Sync Plus
+
+[pages.sync.price]
+original=$4 per month
+translation=Aylık 4$
+
+[pages.sync.pricing_desc]
+original=Easily and securely sync your notes across all your devices. If you’re not satisfied, get a refund within 7 days, no questions\u00a0asked.
+translation=Notlarınızı tüm cihazlarınız arasında kolayca ve güvenle senkronize edin. Memnun kalmazsanız, 7 gün içinde koşulsuz iade alabilirsiniz.
+
+[pages.sync.safe_secure]
+original=Safe and secure
+translation=Güvenli ve emniyetli
+
+[pages.sync.selective_sync_desc]
+original=Images, audio, video and PDFs can all be toggled to reduce data transfer.
+translation=Images, audio, video and PDFs can all be toggled to reduce data transfer.
+
+[pages.sync.standard]
+original=Sync\u00a0Standard
+translation=Sync Standard
+
+[pages.sync.start_syncing_btn]
+original=Start syncing
+translation=Senkronizasyonu başlat
+
+[pages.sync.take_control]
+original=Take control of your\u00a0data
+translation=Verilerinizin kontrolünü elinize alın
+
+[pages.sync.take_control_desc]
+original=Set up Obsidian Sync in just a few\u00a0minutes.
+translation=Obsidian Sync'i sadece birkaç dakika içinde kurun.
+
+[pages.sync.upgradable]
+original=Upgradable to 100\u00a0GB storage
+translation=100 GB depolama alanına yükseltilebilir
+
+[pages.sync.vault_settings]
+original=Vault settings
+translation=Kasa ayarları
+
+[pages.sync.vault_settings_desc]
+original=Sync your hotkeys, file and editor preferences, or individually set them per device.
+translation=Sync your hotkeys, file and editor preferences, or individually set them per device.
+
+[pages.sync.version_history_desc]
+original=Obsidian Sync gives you version history for every note, so you can go back to see how the content changed. It’s easy to see the differences between revisions.
+translation=Obsidian Sync, her not için sürüm geçmişi sunar, böylece içeriğin nasıl değiştiğini görmek için geriye gidebilirsiniz. Revizyonlar arasındaki farkları görmek çok kolaydır.
+
+[shared.accept]
+original=Accept
+translation=Kabul et
+
+[shared.billing_frequency]
+original=Billing frequency
+translation=Faturalandırma sıklığı
+
+[shared.cancel]
+original=Cancel
+translation=İptal
+
+[shared.change_language]
+original=Change language
+translation=Dili değiştir
+
+[shared.close]
+original=Close
+translation=Kapat
+
+[shared.continue]
+original=Continue
+translation=Devam et
+
+[shared.copied]
+original=Copied!
+translation=Kopyalandı!
+
+[shared.credit]
+original=Credit
+translation=Kredi
+
+[shared.go_back]
+original=Go back
+translation=Geri git
+
+[shared.got_it]
+original=Got it
+translation=Anlaşıldı
+
+[shared.monthly]
+original=Monthly
+translation=Aylık
+
+[shared.need_help]
+original=Need help?
+translation=Yardıma mı ihtiyacınız var?
+
+[shared.proceed_to_payment]
+original=Proceed to payment
+translation=Ödemeye geç
+
+[shared.refund_policy]
+original=Refund policy
+translation=İade politikası
+
+[shared.renew_note]
+original=Your plan will renew at {{price}} (before tax and discounts) on {{date}}, unless canceled before that date.
+translation=Planınız, o tarihten önce iptal edilmediği sürece {{date}} tarihinde {{price}} (vergi ve indirimler hariç) üzerinden yenilenecektir.
+
+[shared.renewal_frequency]
+original=Renewal frequency
+translation=Yenileme sıklığı
+
+[shared.save]
+original=Save
+translation=Kaydet
+
+[shared.save_20]
+original=Save 20%
+translation=%20 Tasarruf Et
+
+[shared.successfully_deleted]
+original=Successfully deleted
+translation=Başarıyla silindi
+
+[shared.successfully_updated]
+original=Successfully updated
+translation=Başarıyla güncellendi
+
+[shared.total]
+original=Total
+translation=Toplam
+
+[shared.usd]
+original=USD
+translation=USD
+
+[shared.yearly]
+original=Yearly
+translation=Yıllık
+
+[ui.by]
+original=by
+translation=yazarı:
+
+[ui.contact_us]
+original=contact\u00a0us
+translation=iletişime\u00a0geçin
+
+[ui.docs_btn]
+original=Read the docs
+translation=Dokümanları oku
+
+[ui.e2e]
+original=End-to-end encryption
+translation=Uçtan uca şifreleme
+
+[ui.examples]
+original=Examples
+translation=Örnekler
+
+[ui.faq]
+original=FAQ
+translation=SSS
+
+[ui.features]
+original=Features
+translation=Özellikler
+
+[ui.first_page]
+original=←\u00a0First\u00a0page
+translation=←\u00a0İlk\u00a0sayfa
+
+[ui.follow_news]
+original=Follow the latest Obsidian news
+translation=En son Obsidian haberlerini takip edin
+
+[ui.full_report]
+original=Full report
+translation=Tam rapor
+
+[ui.label_separator]
+original=.
+translation=.
+
+[ui.last_updated]
+original=Last updated
+translation=Son güncelleme
+
+[ui.learn_more]
+original=Learn more
+translation=Daha fazla bilgi edinin
+
+[ui.learn_more_link]
+original=Learn\u00a0more.
+translation=Daha\u00a0fazla\u00a0bilgi\u00a0edinin.
+
+[ui.links]
+original=Links
+translation=Bağlantılar
+
+[ui.monthly]
+original=Monthly
+translation=Aylık
+
+[ui.monthly_billing]
+original=Monthly
+translation=Aylık
+
+[ui.more_browsers]
+original=More browsers
+translation=Daha fazla tarayıcı
+
+[ui.next_page]
+original=Next\u00a0page\u00a0→
+translation=Sonraki\u00a0sayfa\u00a0→
+
+[ui.next_release]
+original=Next release
+translation=Sonraki sürüm
+
+[ui.obsidian_blog]
+original=Obsidian Blog
+translation=Obsidian Blog
+
+[ui.on_date]
+original=on
+translation=tarihinde:
+
+[ui.one_time]
+original=One-time payment
+translation=Tek seferlik ödeme
+
+[ui.per_site_month_monthly]
+original=Per site, per month, billed monthly
+translation=Site başına, aylık, aylık faturalandırılır
+
+[ui.per_site_month_yearly]
+original=Per site, per month, billed annually
+translation=Site başına, aylık, yıllık faturalandırılır
+
+[ui.per_user_month_monthly]
+original=Per user, per month, billed monthly
+translation=Kullanıcı başına, aylık, aylık faturalandırılır
+
+[ui.per_user_month_yearly]
+original=Per user, per month, billed annually
+translation=Kullanıcı başına, aylık, yıllık faturalandırılır
+
+[ui.per_user_year]
+original=Per user, per year
+translation=kullanıcı başına, yıllık
+
+[ui.popular]
+original=Popular
+translation=Popüler
+
+[ui.previous_release]
+original=Previous release
+translation=Önceki sürüm
+
+[ui.pricing]
+original=Pricing
+translation=Ücretlendirme
+
+[ui.read_more]
+original=Read more →
+translation=Daha fazla oku →
+
+[ui.share_post]
+original=Share this post
+translation=Bu gönderiyi paylaş
+
+[ui.sign_up]
+original=Sign up
+translation=Kaydol
+
+[ui.summary]
+original=Summary
+translation=Özet
+
+[ui.use_cases]
+original=Use cases
+translation=Kullanım alanları
+
+[ui.version_history]
+original=Version history
+translation=Sürüm geçmişi
+
+[ui.yearly]
+original=Yearly
+translation=Yıllık
+
+[ui.yearly_billing]
+original=Yearly
+translation=Yıllık

--- a/website/tr.txt
+++ b/website/tr.txt
@@ -4207,8 +4207,8 @@ original=Optional licenses help support the independent development of Obsidian.
 translation=İsteğe bağlı lisanslar, Obsidian'ın bağımsız olarak geliştirilmesini desteklemeye yardımcı olur.
 
 [pages.pricing.vip]
-original=VIP channel
-translation=VIP kanalı
+original=Exclusive channels
+translation=Özel kanallar
 
 [pages.publish.accessible]
 original=Accessible by default
@@ -4766,6 +4766,10 @@ translation=Aylık
 original=Need help?
 translation=Yardıma mı ihtiyacınız var?
 
+[shared.no_results]
+original=No results
+translation=Sonuç bulunamadı
+
 [shared.proceed_to_payment]
 original=Proceed to payment
 translation=Ödemeye geç
@@ -4797,6 +4801,10 @@ translation=Başarıyla silindi
 [shared.successfully_updated]
 original=Successfully updated
 translation=Başarıyla güncellendi
+
+[shared.switch_language]
+original=Switch language...
+translation=Dili değiştir...
 
 [shared.total]
 original=Total
@@ -4890,6 +4898,10 @@ translation=Sonraki\u00a0sayfa\u00a0→
 original=Next release
 translation=Sonraki sürüm
 
+[ui.no_results]
+original=No results
+translation=Sonuç bulunamadı
+
 [ui.obsidian_blog]
 original=Obsidian Blog
 translation=Obsidian Blog
@@ -4949,6 +4961,10 @@ translation=Kaydol
 [ui.summary]
 original=Summary
 translation=Özet
+
+[ui.switch_language]
+original=Switch language...
+translation=Dili değiştir...
 
 [ui.use_cases]
 original=Use cases


### PR DESCRIPTION
## Overview
This PR adds official Turkish (tr) translation support for the Obsidian marketing website (`obsidian.md`).

- **Language:** Turkish
- **Endonym:** Türkçe
- **Key Coverage:** 100% (1,242 keys matched)

## Changes
- Modified `website/locales.json` to register the `tr` locale and its label.
- Added the complete localized strings in `website/tr.txt`.

## Quality & Consistency
- All translations are strictly consistent with the official Obsidian app's Turkish translation (`translations/tr.txt`).
- The project's official validation script has been run locally and passed successfully with zero missing or extra keys:
  ```bash
  node scripts/check-website.mjs
  # Output: tr: OK (1242 keys)