### PR TITLE
Improve German translations for fold commands

### DIFF
--- a/translations/de.txt
+++ b/translations/de.txt
@@ -3844,11 +3844,11 @@ translation=Alle Überschriften und Listen ausklappen
 
 [commands.fold-more]
 original=Fold more
-translation=Noch mehr einklappen
+translation=Aktuelle Überschrift oder Liste einklappen
 
 [commands.fold-less]
 original=Fold less
-translation=Weniger einklappen
+translation=Aktuelle Überschrift oder Liste ausklappen
 
 [commands.swap-line-up]
 original=Move line up
@@ -4456,11 +4456,11 @@ translation=Alle ausklappen
 
 [menu-items.fold-more]
 original=Fold More
-translation=Noch mehr einklappen
+translation=Aktuelle Überschrift oder Liste einklappen
 
 [menu-items.fold-less]
 original=Fold Less
-translation=Weniger einklappen
+translation=Aktuelle Überschrift oder Liste ausklappen
 
 [menu-items.source-mode]
 original=Source Mode


### PR DESCRIPTION
## Summary
This PR improves the German translations for the `Fold more` and `Fold less` commands.

The current translations:

* `Fold more` → `Noch mehr einklappen`
* `Fold less` → `Weniger einklappen`

are quite literal and do not clearly describe what the commands actually do.

This PR changes them to:

* `Fold more` → `Aktuelle Überschrift oder Liste einklappen`
* `Fold less` → `Aktuelle Überschrift oder Liste ausklappen`

The same translations are applied to the corresponding command and menu item entries.

This also makes the wording more consistent with the existing German translations for `Fold all headings and lists` and `Unfold all headings and lists`.
