### PR TITLE
LT: translate Files and links settings

### DIFF
--- a/translations/lt.txt
+++ b/translations/lt.txt
@@ -468,135 +468,135 @@ translation=Naujai sukurti užrašai bus laikomi šiame aplanke.
 
 [setting.file.option-use-wiki-links]
 original=Use [[Wikilinks]]
-translation=
+translation=Naudoti [[vikinuorodas]]
 
 [setting.file.option-use-wiki-links-description]
 original=Auto-generate Wikilinks for [[links]] and ![[images]] instead of Markdown links and images. Disable this option to generate Markdown links instead.
-translation=
+translation=Nuorodas ir paveikslus automatiškai kurti vikinuorodų formatu ([[links]] ir ![[images]]), o ne Markdown formatu. Išjunkite šią parinktį, jei norite kurti Markdown nuorodas.
 
 [setting.file.option-show-unsupported-files]
 original=Show all file types
-translation=Detect all file extensions
+translation=Rodyti visų tipų failus
 
 [setting.file.option-show-unsupported-files-description]
 original=Show files with any extension even if Obsidian can't open them natively, so you can link to them and see them in File Explorer and Quick Switcher.
-translation=Show files with any extension even if Obsidian can't open them natively, so that you can link to them and see them in File Explorer and Quick Switcher.
+translation=Rodyti bet kokio plėtinio failus, net jei Obsidian negali jų atverti tiesiogiai, kad galėtumėte kurti nuorodas į juos ir matyti juos failų naršyklėje bei sparčiajame perjungiklyje.
 
 [setting.file.option-links]
 original=Links
-translation=
+translation=Nuorodos
 
 [setting.file.option-link-autocompleted-format]
 original=New link format
-translation=
+translation=Naujų nuorodų formatas
 
 [setting.file.option-link-autocompleted-format-description]
 original=What links to insert when auto-generating internal links.
-translation=
+translation=Kokias nuorodas įterpti automatiškai kuriant vidines nuorodas.
 
 [setting.file.option-choice-shortest-linktext]
 original=Shortest path when possible
-translation=
+translation=Kai įmanoma, trumpiausias kelias
 
 [setting.file.option-choice-relative-path]
 original=Path from current file
-translation=Relative path to file
+translation=Kelias nuo dabartinio failo
 
 [setting.file.option-choice-absolute-path]
 original=Path from vault folder
-translation=Absolute path in vault
+translation=Kelias nuo saugyklos aplanko
 
 [setting.file.option-new-attachment-location]
 original=Default location for new attachments
-translation=
+translation=Numatytoji naujų priedų vieta
 
 [setting.file.option-new-attachment-location-description]
 original=Where newly added attachments are placed.
-translation=
+translation=Kur dedami naujai pridėti priedai.
 
 [setting.file.option-new-attachment-location-default]
 original=Attachments
-translation=
+translation=Priedai
 
 [setting.file.option-choice-subdirectory]
 original=In subfolder under current folder
-translation=
+translation=Dabartinio aplanko poaplankyje
 
 [setting.file.option-attachment-folder-path]
 original=Attachment folder path
-translation=
+translation=Priedų aplanko kelias
 
 [setting.file.option-attachment-folder-path-description]
 original=Place newly created attachment files, such as images created via drag-and-drop or audio recordings, in this folder.
-translation=
+translation=Šiame aplanke laikyti naujai sukurtus priedų failus, pvz., nuvelkant pridėtus paveikslus ar garso įrašus.
 
 [setting.file.option-attachment-subfolder-path]
 original=Subfolder name
-translation=
+translation=Poaplankio pavadinimas
 
 [setting.file.option-attachment-subfolder-path-description]
 original=If your file is in “vault/folder”, and you set subfolder name to “attachments”, attachments will be saved to “vault/folder/attachments”.
-translation=If your file is under "vault/folder", and you set subfolder name to "attachments", attachments will be saved to "vault/folder/attachments".
+translation=Jei failas yra vault/folder, o poaplankio pavadinimas — attachments, priedai bus įrašomi į vault/folder/attachments.
 
 [setting.file.option-excluded-files]
 original=Excluded files
-translation=
+translation=Neįtraukiami failai
 
 [setting.file.option-excluded-files-desc]
 original=Excluded files will be hidden in Search, Graph View, and Unlinked Mentions, less noticeable in Quick Switcher and link suggestions.
-translation=
+translation=Neįtraukiami failai bus paslėpti paieškoje, grafo rodinyje ir nesusietuose paminėjimuose, mažiau pastebimi sparčiajame perjungiklyje ir nuorodų pasiūlymuose.
 
 [setting.file.label-add-excluded-filter]
 original=Add exclusion...
-translation=
+translation=Pridėti neįtraukimo taisyklę...
 
 [setting.file.label-no-excluded-filters]
 original=No exclusions added.
-translation=
+translation=Neįtraukimo taisyklių nepridėta.
 
 [setting.file.label-excluded-files-count]
 original={{count}} rule
-translation=
+translation=Taisyklių: {{count}}
 
 [setting.file.label-excluded-files-count_plural]
 original={{count}} rules
-translation=
+translation=Taisyklių: {{count}}
 
 [setting.file.title-add-excluded-filter]
 original=Add exclusion
-translation=
+translation=Pridėti neįtraukimo taisyklę
 
 [setting.file.help-excluded-filter]
 original=Enter a path or a regular expression, e.g. /daily-.*/
-translation=
+translation=Įveskite kelią arba reguliariąją išraišką, pvz., /daily-.*/
 
 [setting.file.message-empty-filter]
 original=Filter cannot be empty
-translation=
+translation=Filtras negali būti tuščias
 
 [setting.file.option-uri-callbacks]
 original=Allow URI callbacks
-translation=
+translation=Leisti URI atgalinius iškvietimus
 
 [setting.file.option-uri-callbacks-desc]
 original=Enable the use of x-callback-url through x-success or x-error when handling Obsidian URIs.
-translation=
+translation=Apdorojant Obsidian URI, leisti naudoti x-callback-url su x-success arba x-error.
 
 [setting.file.label-obsidian-uri]
 original=Obsidian URI
-translation=
+translation=Obsidian URI
 
 [setting.file.label-obsidian-uri-desc]
 original=Manage trusted actions and configure URI behavior.
-translation=
+translation=Tvarkykite patikimus veiksmus ir nustatykite URI veikimą.
 
 [setting.file.label-trusted-uri-actions]
 original=Trusted actions
-translation=
+translation=Patikimi veiksmai
 
 [setting.file.label-no-trusted-uri-actions]
 original=No trusted actions yet. Approved URI actions will appear here.
-translation=
+translation=Patikimų veiksmų dar nėra. Čia bus rodomi patvirtinti URI veiksmai.
 
 [setting.appearance.name]
 original=Appearance

--- a/translations/lt.txt
+++ b/translations/lt.txt
@@ -344,127 +344,127 @@ translation=
 
 [setting.file.name]
 original=Files and links
-translation=Files & Links
+translation=Failai ir nuorodos
 
 [setting.file.option-confirm-file-deletion]
 original=Confirm before deleting files
-translation=Patvirtinti prieš ištrinant failus
+translation=Prieš trinant failus prašyti patvirtinimo
 
 [setting.file.option-confirm-file-deletion-description]
 original=Avoid accidentally deleting files.
-translation=Padeda išvengti atsitiktinio failų ištrynimo.
+translation=Padeda išvengti netyčinio failų ištrynimo.
 
 [setting.file.option-trash]
 original=Trash
-translation=
+translation=Šiukšlinė
 
 [setting.file.option-delete-destination]
 original=Deleted files
-translation=
+translation=Ištrinti failai
 
 [setting.file.option-delete-destination-description]
 original=What happens to a file after you delete it.
-translation=
+translation=Kas nutinka ištrintam failui.
 
 [setting.file.option-choice-system-trash]
 original=Move to system trash
-translation=
+translation=Perkelti į sistemos šiukšlinę
 
 [setting.file.option-choice-vault-trash]
 original=Move to Obsidian trash (.trash folder)
-translation=
+translation=Perkelti į Obsidian šiukšlinę (aplanką .trash)
 
 [setting.file.option-choice-permanent-delete]
 original=Permanently delete
-translation=
+translation=Ištrinti visam laikui
 
 [setting.file.option-delete-unlinked-attachments]
 original=Delete attachments when deleting files
-translation=
+translation=Ištrinti priedus kartu su failais
 
 [setting.file.option-delete-unlinked-attachments-description]
 original=Automatically remove attachments linked to the deleted file if they're not used elsewhere.
-translation=
+translation=Automatiškai pašalinti su ištrintu failu susietus priedus, jei jie niekur kitur nenaudojami.
 
 [setting.file.option-choice-always]
 original=Always
-translation=
+translation=Visada
 
 [setting.file.option-choice-ask-every-time]
 original=Ask each time
-translation=
+translation=Kaskart klausti
 
 [setting.file.option-choice-never]
 original=Never
-translation=
+translation=Niekada
 
 [setting.file.option-default-open-action]
 original=Default file to open
-translation=
+translation=Numatytasis atveriamas failas
 
 [setting.file.option-default-open-action-description]
 original=Choose which file to open when the app starts.
-translation=
+translation=Pasirinkite, kurį failą atverti paleidus programą.
 
 [setting.file.option-choice-last-opened]
 original=Last opened
-translation=
+translation=Paskutinis atvertas
 
 [setting.file.option-choice-new-note]
 original=New note
-translation=
+translation=Naujas užrašas
 
 [setting.file.option-choice-specific-file]
 original=Specific file
-translation=
+translation=Konkretus failas
 
 [setting.file.option-choice-daily-note]
 original=Daily note
-translation=
+translation=Dienos užrašas
 
 [setting.file.option-default-open-file-path]
 original=File to open
-translation=
+translation=Atveriamas failas
 
 [setting.file.option-default-open-file-path-description]
 original=Select a specific file to open by default.
-translation=
+translation=Pasirinkite konkretų failą, kuris bus atveriamas pagal numatytuosius nustatymus.
 
 [setting.file.option-always-update-links]
 original=Automatically update internal links
-translation=
+translation=Automatiškai atnaujinti vidines nuorodas
 
 [setting.file.option-always-update-links-description]
 original=Turn off to be prompted to update links after renaming a file.
-translation=
+translation=Išjunkite, kad pervadinus failą būtų klausiama, ar atnaujinti nuorodas.
 
 [setting.file.option-new-note-location]
 original=Default location for new notes
-translation=
+translation=Numatytoji naujų užrašų vieta
 
 [setting.file.option-new-note-location-description]
 original=Where newly created notes are placed.
-translation=
+translation=Nurodo, kur dedami naujai sukurti užrašai.
 
 [setting.file.option-choice-vault-root]
 original=Vault folder
-translation=
+translation=Saugyklos aplankas
 
 [setting.file.option-choice-current-folder]
 original=Same folder as current file
-translation=
+translation=Dabartinio failo aplankas
 
 [setting.file.option-choice-specified-folder]
 original=In the folder specified below
-translation=
+translation=Toliau nurodytame aplanke
 
 [setting.file.option-new-file-folder-path]
 original=Folder to create new notes in
-translation=
+translation=Naujų užrašų aplankas
 
 [setting.file.option-new-file-folder-path-description]
 original=Newly created notes will appear in this folder.
-translation=Newly created notes will appear under this folder.
+translation=Naujai sukurti užrašai bus laikomi šiame aplanke.
 
 [setting.file.option-use-wiki-links]
 original=Use [[Wikilinks]]


### PR DESCRIPTION
## Summary

- Translate all 64 strings in the Files and links settings section into Lithuanian.
- Replace incomplete or English values already present in this section.
- Keep placeholders, Markdown syntax, file paths, regular expressions, and Obsidian URI parameters intact.

Language endonym: Lietuvių

## Validation

- Loaded the updated lt.txt with selectLanguageFileLocation().
- Manually reviewed and tested the complete Files and links settings section in Obsidian.
- Verified that only translation values changed; section keys and original values are unchanged.
- Verified terminology consistency and file integrity.