### PR TITLE
One line fix translation for vault size description in PT-BR

### DIFF
--- a/translations/pt-BR.txt
+++ b/translations/pt-BR.txt
@@ -7672,7 +7672,7 @@ translation=Tamanho do cofre:
 
 [plugins.sync.option-vault-size-desc]
 original=You are using {{size}} out of {{limit}}
-translation=Você está usando {{size}} além do limite de {{limit}}
+translation=Você está usando {{size}} de {{limit}} disponíveis
 
 [plugins.sync.option-vault-size-unknown]
 original=Unable to retrieve your vault size.


### PR DESCRIPTION
In Brazilian Portuguese, the original text _"Você está usando {{size}} além do limite de {{limit}}"_ gives off the idea that the value on {{size}} has exceeded the limited value. 

It's essentially as if it were to say: "You are using {{size}} MB over the {{limit}} GB."

Because of this, the text has been changed to: "Você está usando {{size}} de {{limit}} disponíveis", a more appropriate translation.