### PR TITLE
Fix Russian 'navigate forward' spelling

### DIFF
--- a/translations/ru.txt
+++ b/translations/ru.txt
@@ -3728,7 +3728,7 @@ translation=Вернуться назад
 
 [commands.navigate-forward]
 original=Navigate forward
-translation=Перейти вперед
+translation=Перейти вперёд
 
 [commands.toggle-light-dark-mode]
 original=Toggle light/dark mode
@@ -4500,7 +4500,7 @@ translation=Вернуться назад
 
 [menu-items.navigate-forward]
 original=Navigate Forward
-translation=Перейти вперед
+translation=Перейти вперёд
 
 [menu-items.toggle-left-sidebar]
 original=Left Sidebar


### PR DESCRIPTION
Correct the Russian translation for the forward navigation action and menu item by using the proper spelling with ё in 'вперёд'.