### PR TITLE
Fix typo in Dutch translation

### DIFF
--- a/translations/nl.txt
+++ b/translations/nl.txt
@@ -1764,7 +1764,7 @@ translation=Laad plug-ins opnieuw
 
 [setting.third-party-plugin.msg-reloaded-third-party-plugins]
 original=Reloaded third-party plugins.
-translation=Opnieuw laden vam plug-ins van derden.
+translation=Opnieuw laden van plug-ins van derden.
 
 [setting.third-party-plugin.label-uninstall]
 original=Uninstall


### PR DESCRIPTION
Fixes `vam` → `van` in the Dutch translation for reloading third-party plugins.